### PR TITLE
Solve bug on fastagi unregister_script_handler method.  

### DIFF
--- a/pystrix/agi/fastagi.py
+++ b/pystrix/agi/fastagi.py
@@ -189,7 +189,7 @@ class FastAGIServer(_ThreadedTCPServer):
         with self._script_handlers_lock:
             for (i, (old_regex, old_handler)) in enumerate(self._script_handlers):
                 if old_regex == regex:
-                    self._script_handlers.remove(i)
+                    self._script_handlers.pop(i)
                     break
 
 class FastAGI(_AGI):


### PR DESCRIPTION
It was crashing because it sends index to the remove list method and remove just works with an element, pop works with indexes.