### PR TITLE
Added QueueSummary command

### DIFF
--- a/pystrix/ami/core.py
+++ b/pystrix/ami/core.py
@@ -995,6 +995,27 @@ class QueueStatus(_Request):
         if not queue is None:
             self['Queue'] = queue
 
+         
+class QueueSummary(_Request):
+    """
+    Describes the Summary of one (or all) queues.
+
+    Upon success, 'QueueSummary' event will be generated, ending
+    with 'QueueSummaryComplete'.
+    """
+    _aggregates = (core_events.QueueSummary_Aggregate,)
+    _synchronous_events_list = (core_events.QueueSummary,)
+    _synchronous_events_finalising = (core_events.QueueSummaryComplete,)
+
+    def __init__(self, queue=None):
+        """
+        Describes all queues in the system, unless `queue` is given, which limits the scope to one.
+        """
+        _Request.__init__(self, "QueueSummary")
+        if not queue is None:
+            self['Queue'] = queue
+          
+          
 class Redirect(_Request):
     """
     Redirects a call to an arbitrary context/extension/priority.

--- a/pystrix/ami/core_events.py
+++ b/pystrix/ami/core_events.py
@@ -567,6 +567,40 @@ class QueueStatusComplete(_Event):
     Indicates that a QueueStatus request has completed.
     """
 
+class QueueSummary(_Event):
+    """
+    Describes a Summary of a queue.
+
+    Event: QueueSummary
+    Queue: default
+    LoggedIn: 0
+    Available: 0
+    Callers: 0
+    HoldTime: 0
+    TalkTime: 0
+    LongestHoldTime: 0
+
+    Event: QueueSummaryComplete
+    EventList: Complete
+    ListItems: 2
+
+    """
+
+    def process(self):
+        """
+        """
+        (headers, data) = _Event.process(self)
+        generic_transforms.to_int(headers, ('LoggedIn', 'Available', 'Callers', 'HoldTime', 'TalkTime',
+                                            'LongestHoldTime'), -1)
+        return (headers, data)
+
+
+class QueueSummaryComplete(_Event):
+    """
+    Indicates that a QueueStatus request has completed.
+    """
+
+
 class RegistryEntry(_Event):
     """
     Describes a SIP registration.
@@ -897,7 +931,22 @@ class QueueStatus_Aggregate(_Aggregate):
     
     _aggregation_members = (QueueParams, QueueMember, QueueEntry,)
     _aggregation_finalisers = (QueueStatusComplete,)
-    
+
+
+class QueueSummary_Aggregate(_Aggregate):
+    """
+    Emitted after all queue properties have been received in response to a QueueSummary request.
+
+    Its members consist of QueueSummary events.
+
+    It is finalised by QueueSummaryComplete.
+    """
+    _name = "QueueSummary_Aggregate"
+
+    _aggregation_members = (QueueSummary,)
+    _aggregation_finalisers = (QueueSummaryComplete,)
+	
+
 class SIPpeers_Aggregate(_Aggregate):
     """
     Emitted after all queue properties have been received in response to a SIPpeers request.


### PR DESCRIPTION
This pull request to added the new `QueueSummary` AMI command to the list.

`QueueSummary` output example from AMI:

`
Action: QueueSummary

Response: Success
EventList: start
Message: Queue summary will follow

Event: QueueSummary
Queue: default
LoggedIn: 0
Available: 0
Callers: 0
HoldTime: 0
TalkTime: 0
LongestHoldTime: 0

Event: QueueSummary
Queue: 999
LoggedIn: 1
Available: 1
Callers: 0
HoldTime: 15
TalkTime: 12
LongestHoldTime: 0

Event: QueueSummaryComplete
EventList: Complete
ListItems: 2
`
And from the library:

`
{'Available': '0', 'LoggedIn': '0', 'TalkTime': '0', 'LongestHoldTime': '0', 'Queue': 'default', 'Callers': '0', 'ActionID': 'kholioeg-ThinkPad-T430-jwo1R-00000003', 'HoldTime': '0', 'Event': 'QueueSummary'}
{'Available': '1', 'LoggedIn': '1', 'TalkTime': '12', 'LongestHoldTime': '0', 'Queue': '999', 'Callers': '0', 'ActionID': 'kholioeg-ThinkPad-T430-jwo1R-00000003', 'HoldTime': '15', 'Event': 'QueueSummary'}
`