### PR TITLE
Fixed an issue where pystrix would raise an error and not let any fur…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,6 @@ Other contributions
 [Eric Lee](eric@ivrtechnology.com)
  * Python 2 to 3 migration - compatibility
  * Programming
+
+[Karthic Raghupathi](karthicr@gmail.com)
+ * Bug Fixes / Programming

--- a/pystrix/agi/agi_core.py
+++ b/pystrix/agi/agi_core.py
@@ -154,14 +154,15 @@ class _AGI(object):
                 }, response)
 
             result = response.get(_RESULT_KEY)
-            if result.value == '-1': #A result of -1 always indicates failure
-                raise AGIAppError("Error executing application or the channel was hung up", response)
             if check_hangup and result.data == 'hangup': #A 'hangup' response usually indicates that the channel was hungup, but it is a legal variable value
                 raise AGIResultHangup("User hung up during execution", response)
                 
             return _Response(response, code, raw)
         elif code == 0:
-            raise AGIResultHangup("Call hung up")
+            # No code was returned by Asterisk.
+            # The only other possible codes returned by Asterisk are 200, 510, 511 and 520 which is being handled.
+            # We probably got a signal like SIGHUP, so move on and do nothing
+            pass
         elif code == 510:
             raise AGIInvalidCommandError(response)
         elif code == 511:
@@ -196,7 +197,7 @@ class _AGI(object):
                 if key:
                     self._environment[key] = data
                     
-    def _read_line(self):
+    def _read_line(self, should_strip=True):
         """
         Reads and returns a line from the Asterisk pipe, blocking until a complete line is
         assembled.
@@ -209,13 +210,20 @@ class _AGI(object):
                 line = line.decode()  # decode line if it comes in bytes, example if it comes from a socket
             except:
                 pass  # line it's a string, so nothing to change - it's string if it's using stdin as _rfile for example
+            # Check to see if we received a HANGUP because AGISIGHUP was not set explicitly or is no
+            # and then handle the HANGUP which is being returned because the AGI script can still interact with
+            # Asterisk after the call was hungup in DeadAGI mode (which Asterisk converts the channel to automatically)
+            # All commands won't work in DeadAGI but that is not our concern here because if such a command is issued
+            # which indeed requires channel interaction, Asterisk will respond with a 511 code.
+            if 'no' == self._environment.get('AGISIGHUP', 'no') and 'HANGUP\n' == line:
+                line = self._read_line(should_strip=False) # read from pipe again to get response for the given command
             if not line: #EOF encountered
                 raise AGISIGPIPEHangup("Process input pipe closed")
             elif not line.endswith('\n'): #Fragment encountered
                 #Recursively append to the current fragment until the line is
                 #complete or the socket dies.
                 line += self._read_line()
-            return line.strip()
+            return line.strip() if should_strip else line
         except IOError as e:
             raise AGISIGPIPEHangup("Process input pipe broken: %(error)s" % {
              'error': str(e),
@@ -284,9 +292,9 @@ class AGIException(Exception):
     """
     items = None #Any items received from Asterisk, as a dictionary.
 
-    def __init__(self, message, items={}):
+    def __init__(self, message, items=None):
         Exception.__init__(self, message)
-        self.items = items
+        self.items = items if items else {}
         
 class AGIError(AGIException):
     """


### PR DESCRIPTION
…ther interaction occur after the called party hung up during AGI script execution.

* A result of -1 always indicates application did not exit successfully. But that doesn't mean an AGIAppError should be raised because Asterisk further interaction with Asterisk is possible and sometimes needed for tasks that include fetching channel variables. I've removed the piece of code that raised the error.
* Raising an AGIResultHangup if no code was returned from Asterisk is wrong behavior as we could be receiving signals from Asterisk that include a HANGUP because AGISIGHUP was not set to no. Further execution of the AGI application / dialplan is necessary as indicated earlier. I've removed the piece of code raised the error.
* I've modified the _read_line() method to now perform a recursive read when a HANGUP signal is received so it can actually read the response for an actual command issued earlier from the pipe. This is because Asterisk automatically adjusts its operation to be in DeadAGI mode and further interaction with between AGI script and Asterisk is possible as long as commands that do not require channel interaction are issued. To view a list of commands that can run in DeadAGI mode, run the following command in the Asterisk CLI: agi show commands
* I also fixed the mutable default parameter in the constructor for the AGIException class.
* Added name to contributors section.