### PR TITLE
amy.py changes needed to run on a Python 3.4.3 environment.

### DIFF
--- a/pystrix/ami/ami.py
+++ b/pystrix/ami/ami.py
@@ -529,7 +529,11 @@ class Manager(object):
                         })
 
         start_time = time.time()
-        timeout = start_time + request.timeout
+        if request['Action'] == 'Originate':
+            # timeout is in millisecs
+            timeout = start_time + (request.timeout / 1000)
+        else:
+            timeout = start_time + request.timeout
         response = processed_response = success = None
         events_timeout = False
         while time.time() < timeout:

--- a/pystrix/ami/ami.py
+++ b/pystrix/ami/ami.py
@@ -902,7 +902,7 @@ class _Request(dict):
         The 'Action' line is always first.
         """
         items = [(KEY_ACTION, self[KEY_ACTION])]
-        for (key, value) in [(k, v) for (k, v) in self.items() if not k in (KEY_ACTION, KEY_ACTIONID)] + kwargs.items():
+        for (key, value) in [(k, v) for (k, v) in self.items() if not k in (KEY_ACTION, KEY_ACTIONID)] + list(kwargs.items()):
             key = str(key)
             if type(value) in (tuple, list, set, frozenset):
                 for val in value:
@@ -1139,6 +1139,8 @@ class _SynchronisedSocket(object):
                 except AttributeError:
                     raise ManagerSocketError("Local socket no longer defined, caused by system shutdown and blocking I/O")
 
+            line = "{0}\r\n".format(line.rstrip()) #Make sure line termination complies with _EOL
+            
             if line == _EOL and not wait_for_marker:
                 if response_lines: #A full response has been collected
                     return _Message(response_lines)
@@ -1164,6 +1166,8 @@ class _SynchronisedSocket(object):
             
         with self._socket_write_lock:
             try:
+                if type(message) == str:
+                    message = message.encode('utf-8') #socket3.sendall expects byte, no string type            
                 self._socket.sendall(message)
             except socket.error as e:
                 self._close()

--- a/pystrix/ami/core.py
+++ b/pystrix/ami/core.py
@@ -637,7 +637,7 @@ class _Originate(_Request):
     
     Requires call
     """
-    def __init__(self, channel, timeout=None, callerid=None, variables={}, account=None, async=True):
+    def __init__(self, channel, timeout=None, callerid=None, variables={}, account=None, async_=True):
         """
         Sets common parameters for originated calls.
 
@@ -659,11 +659,11 @@ class _Originate(_Request):
         `account` is an optional account code to be associated with the channel, useful for tracking
         billing information.
 
-        `async` should always be `True`. If not, only one unanswered call can be active at a time.
+        `async_` should always be `True`. If not, only one unanswered call can be active at a time.
         """
         _Request.__init__(self, "Originate")
         self['Channel'] = channel
-        self['Async'] = async and 'true' or 'false'
+        self['Async'] = async_ and 'true' or 'false'
         
         if timeout and timeout > 0:
             self['Timeout'] = str(timeout)
@@ -686,7 +686,7 @@ class Originate_Application(_Originate):
     
     Requires call
     """
-    def __init__(self, channel, application, data=(), timeout=None, callerid=None, variables={}, account=None, async=True):
+    def __init__(self, channel, application, data=(), timeout=None, callerid=None, variables={}, account=None, async_=True):
         """
         `channel` is the destination to be called, expressed as a fully qualified Asterisk channel,
         like "SIP/test-account@example.org".
@@ -710,9 +710,9 @@ class Originate_Application(_Originate):
         `account` is an optional account code to be associated with the channel, useful for tracking
         billing information.
 
-        `async` should always be `True`. If not, only one unanswered call can be active at a time.
+        `async_` should always be `True`. If not, only one unanswered call can be active at a time.
         """
-        _Originate.__init__(self, channel, timeout, callerid, variables, account, async)
+        _Originate.__init__(self, channel, timeout, callerid, variables, account, async_)
         self['Application'] = application
         if data:
             self['Data'] = ','.join((str(d) for d in data))
@@ -723,7 +723,7 @@ class Originate_Context(_Originate):
     
     Requires call
     """
-    def __init__(self, channel, context, extension, priority, timeout=None, callerid=None, variables={}, account=None, async=True):
+    def __init__(self, channel, context, extension, priority, timeout=None, callerid=None, variables={}, account=None, async_=True):
         """
         `channel` is the destination to be called, expressed as a fully qualified Asterisk channel,
         like "SIP/test-account@example.org".
@@ -747,9 +747,9 @@ class Originate_Context(_Originate):
         `account` is an optional account code to be associated with the channel, useful for tracking
         billing information.
 
-        `async` should always be `True`. If not, only one unanswered call can be active at a time.
+        `async_` should always be `True`. If not, only one unanswered call can be active at a time.
         """
-        _Originate.__init__(self, channel, timeout, callerid, variables, account, async)
+        _Originate.__init__(self, channel, timeout, callerid, variables, account, async_)
         self['Context'] = context
         self['Exten'] = extension
         self['Priority'] = priority


### PR DESCRIPTION
Making read_message.line comply with _EOL termination as we were detecting single \n terminations coming from readline (from a pretty standard Asterisk 13.19.1 installation) that was causing the event read never to be completed and Asterisk dropping the connection after the Login timeout.

Making send_action.message byte as sockets3.sendall now expectes Byte instead of str as in sockets2

Casting dictionary to list to correct issue on line #905