### PR TITLE
Python 2 & 3+ Compatible AMI Response Line Ending Fix

### DIFF
--- a/pystrix/ami/core.py
+++ b/pystrix/ami/core.py
@@ -442,7 +442,9 @@ class Login(_Request):
         if not challenge is None and authtype:
             self['AuthType'] = authtype
             if authtype == AUTHTYPE_MD5:
-                self['Key'] = hashlib.md5(challenge + secret).hexdigest()
+                self['Key'] = hashlib.md5(
+                    generic_transforms.string_to_bytes(challenge + secret)
+                ).hexdigest()
             else:
                 raise ManagerAuthError("Invalid AuthType specified: %(authtype)s" % {
                  'authtype': authtype,
@@ -1377,4 +1379,3 @@ class ManagerAuthError(ManagerError):
     """
     Indicates that a problem occurred while authenticating 
     """
-    

--- a/pystrix/ami/generic_transforms.py
+++ b/pystrix/ami/generic_transforms.py
@@ -28,6 +28,13 @@ Authors:
 
 - Neil Tallim <flan@uguu.ca>
 """
+import sys
+
+
+# identify string type in a python 2 and 3 compatible manner
+string_type = str if sys.version_info[0] >= 3 else basestring
+
+
 def to_bool(dictionary, keys, truth_value=None, truth_function=(lambda x:bool(x)), preprocess=(lambda x:x)):
     for key in keys:
         if truth_value:
@@ -51,4 +58,15 @@ def to_int(dictionary, keys, failure_value, preprocess=(lambda x:x)):
             dictionary[key] = int(preprocess(dictionary.get(key)))
         except Exception:
             dictionary[key] = failure_value
-            
+
+
+def string_to_bytes(value, encoding="utf-8", errors="strict"):
+    if isinstance(value, string_type):
+        return value.encode(encoding, errors)
+    return value
+
+
+def bytes_to_string(value, encoding="utf-8", errors="strict"):
+    if not isinstance(value, string_type):
+        return value.decode(encoding, errors)
+    return value


### PR DESCRIPTION
* While this was already fixed in an earlier commit, this patch addresses the actual underlying cause IMHO.
* Responses from Asterisk were being read with mode="r" in readline() causing the carriage return to be dropped silently as described in https://bugs.python.org/issue10041.
* This is the underlying cause and the right way to fix this is to switch to using mode="rb" in readline().
* I've added convenience methods in the generic_transforms module to convert to and from string and bytes in a Python 2 and 3+ compatible fashion.
* These convenience methods are being used to coerce strings to bytes and vice versa where required.
* As a result, I've removed the earlier code that fixed the issue in an alternate fashion.

This patch has been tested on both Python 2 and 3. Fixes #21.