### PR TITLE
ORIGINATE_RESULT Constant For Reason 0 & Enhancing Process for OriginateResponse AMI Event

### DIFF
--- a/pystrix/ami/core.py
+++ b/pystrix/ami/core.py
@@ -65,6 +65,7 @@ FORMAT_VOX = 'vox'
 FORMAT_WAV = 'wav'
 
 #Originate result constants
+#https://github.com/asterisk/asterisk/blob/56028426de0692e8e36167251053c91b96e97c41/include/asterisk/frame.h#L277
 ORIGINATE_RESULT_REJECT = 1 #Remote hangup
 ORIGINATE_RESULT_RING_LOCAL = 2
 ORIGINATE_RESULT_RING_REMOTE = 3
@@ -72,6 +73,20 @@ ORIGINATE_RESULT_ANSWERED = 4
 ORIGINATE_RESULT_BUSY = 5
 ORIGINATE_RESULT_CONGESTION = 8
 ORIGINATE_RESULT_INCOMPLETE = 30 #Unable to resolve
+#Reason 0 is not documented in source
+#https://github.com/asterisk/asterisk/blob/56028426de0692e8e36167251053c91b96e97c41/main/manager.c#L5446
+#External reference https://www.voip-info.org/asterisk-manager-api-action-originate/
+ORIGINATE_RESULT_BAD_NUMBER = 0 #No such number/extension or bad technology
+ORIGINATE_RESULT_MAP = {
+    ORIGINATE_RESULT_BAD_NUMBER: 'BAD_NUMBER',
+    ORIGINATE_RESULT_REJECT: 'REJECTED',
+    ORIGINATE_RESULT_RING_LOCAL: 'RINGING',
+    ORIGINATE_RESULT_RING_REMOTE: 'RINGING',
+    ORIGINATE_RESULT_ANSWERED: 'ANSWERED',
+    ORIGINATE_RESULT_BUSY: 'BUSY',
+    ORIGINATE_RESULT_CONGESTION: 'CONGESTION',
+    ORIGINATE_RESULT_INCOMPLETE: 'INCOMPLETE'
+}
 
 class AbsoluteTimeout(_Request):
     """

--- a/pystrix/ami/core_events.py
+++ b/pystrix/ami/core_events.py
@@ -34,7 +34,7 @@ http://www.asteriskdocs.org/ and https://wiki.asterisk.org/
 import re
 
 from pystrix.ami.ami import (_Aggregate, _Event)
-from pystrix.ami import generic_transforms
+from pystrix.ami import core, generic_transforms
 
 class AGIExec(_Event):
     """
@@ -327,6 +327,7 @@ class OriginateResponse(_Event):
         """
         (headers, data) = _Event.process(self)
         generic_transforms.to_int(headers, ('Reason',), -1)
+        generic_transforms.add_result(headers, 'Reason', core.ORIGINATE_RESULT_MAP)
         return (headers, data)
         
 class ParkedCall(_Event):

--- a/pystrix/ami/generic_transforms.py
+++ b/pystrix/ami/generic_transforms.py
@@ -44,20 +44,27 @@ def to_bool(dictionary, keys, truth_value=None, truth_function=(lambda x:bool(x)
                 dictionary[key] = truth_function(preprocess(dictionary.get(key)))
             except Exception:
                 dictionary[key] = False
-                
+
+
 def to_float(dictionary, keys, failure_value, preprocess=(lambda x:x)):
     for key in keys:
         try:
             dictionary[key] = float(preprocess(dictionary.get(key)))
         except Exception:
             dictionary[key] = failure_value
-            
+
+
 def to_int(dictionary, keys, failure_value, preprocess=(lambda x:x)):
     for key in keys:
         try:
             dictionary[key] = int(preprocess(dictionary.get(key)))
         except Exception:
             dictionary[key] = failure_value
+
+
+def add_result(dictionary, key, result_map):
+    if dictionary[key] in result_map:
+        dictionary['Result'] = result_map[dictionary[key]]
 
 
 def string_to_bytes(value, encoding="utf-8", errors="strict"):


### PR DESCRIPTION
* Added a new `ORIGINATE_RESULT` constant for reason 0.
* Added a reverse map to allow for adding a `Result` header to the headers list which maps integer reason code to textual values with meaning.
* Added a new method `add_result()` to the `generic_transforms` module to add a new `Result` header to the processed headers list.
* Called this new `add_result` method in the `process()` method of the `OriginateResponse` class to add the `Result` header to the processed headers list which provides users with additional clarity as to what the `Reason` code means.
