### PR TITLE
FastAGIServer and AMI Updates

### DIFF
--- a/pystrix/__init__.py
+++ b/pystrix/__init__.py
@@ -42,5 +42,5 @@ Authors:
 import pystrix.agi
 import pystrix.ami
 
-VERSION = '1.1.9'
+VERSION = '1.2.0'
 COPYRIGHT = '2013, Neil Tallim <flan@uguu.ca>'

--- a/pystrix/__init__.py
+++ b/pystrix/__init__.py
@@ -42,5 +42,5 @@ Authors:
 import pystrix.agi
 import pystrix.ami
 
-VERSION = '1.1.8'
+VERSION = '1.1.9'
 COPYRIGHT = '2013, Neil Tallim <flan@uguu.ca>'

--- a/pystrix/agi/fastagi.py
+++ b/pystrix/agi/fastagi.py
@@ -36,19 +36,17 @@ Authors:
 - Neil Tallim <n.tallim@ivrnet.com>
 """
 import cgi
-import re
+import platform
 import socket
+import subprocess
 import threading
-import types
 from pystrix.agi.agi_core import *
 from pystrix.agi.agi_core import _AGI
 
 try:
-	import socketserver
-except:
-	import SocketServer as socketserver
-
-
+    import socketserver
+except ModuleNotFoundError:
+    import SocketServer as socketserver
 
 
 class _ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
@@ -56,10 +54,40 @@ class _ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     Provides a variant of the TCPServer that spawns a new thread to handle each
     request.
     """
-    def server_bind(self):
-        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        socketserver.TCPServer.server_bind(self)
-        
+
+    @staticmethod
+    def get_somaxconn():
+        """
+        Returns the value of SOMAXCONN configured in the system.
+        """
+        # determine the OS appropriate management informations base (MIB)
+        # name to determine SOMAXCONN
+        system = platform.system()
+        if "Linux" == system:
+            sysctl_mib_somaxconn = "net.core.somaxconn"
+            sysctl_output_delimiter = "="
+        elif "Darwin" == system:
+            sysctl_mib_somaxconn = "kern.ipc.somaxconn"
+            sysctl_output_delimiter = ":"
+        else:
+            raise NotImplementedError(
+                "Determining SOMAXCONN is not implemented for {} system.".format(system)
+            )
+        # run the cmd to determine the SOMAXCONN
+        cmd_result = subprocess.check_output(["sysctl", sysctl_mib_somaxconn])
+
+        # parse the output of the cmd to return the value of SOMAXCONN
+        return int(cmd_result.decode().split(sysctl_output_delimiter)[-1].strip())
+
+    def __init__(self, *args, **kwargs):
+        # adjust request queue size to a saner value for modern systems
+        # further adjustments are automatically picked up for kernel
+        # settings on server start
+        self.request_queue_size = max(socket.SOMAXCONN, self.get_somaxconn())
+        self.allow_reuse_address = True
+        super().__init__(*args, **kwargs)
+
+
 class _AGIClientHandler(socketserver.StreamRequestHandler):
     """
     Handles TCP connections.

--- a/pystrix/ami/ami.py
+++ b/pystrix/ami/ami.py
@@ -1083,6 +1083,9 @@ class _SynchronisedSocket(object):
         """
         Release resources associated with this connection.
         """
+        if self._socket_write_lock is None:
+            self._close()
+            return
         with self._socket_write_lock as write_lock:
             self._close()
             

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Communications :: Telephony'
 ]
 


### PR DESCRIPTION
# Fixes
- Close socket in a cleaner fashion when connection to Asterisk fails.
  - This fix resolves issues #2 and #24. Thanks to @bhymel for the fix.

# Enhancement
- Increase the request queue size for the FastAGIServer from 5 to a minimum of 128. The maximum value is now read from the value of SOMAXCONN configured in the system.
  - This enhancement allows the ability of the FastAgiServer to utilize the existing hardware to the maximum potential and also allows it to scale with increased hardware capacity.