### PR TITLE
Add GitHub Actions CI across Python 3.9-3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package
+        run: pip install -e .
+      - name: Import smoke test
+        run: |
+          python -c "import pystrix; from pystrix.agi import FastAGIServer; from pystrix.ami import Manager; print('pystrix', pystrix.VERSION, 'imports on', __import__('sys').version.split()[0])"
+
+  docs:
+    name: Documentation build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install -r doc/requirements.txt
+      - name: Build docs with warnings as errors
+        run: sphinx-build -W --keep-going -b html doc doc/_build/html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,14 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -28,6 +32,7 @@ jobs:
   docs:
     name: Documentation build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,19 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CLAUDE.md` pointing to `AGENTS.md`.
 - A Contributing section and AGI, FastAGI, and AMI quick-start examples in the README.
 - `.readthedocs.yaml` and `doc/requirements.txt` for reproducible documentation builds.
+- A GitHub Actions CI workflow that installs the package and runs an import smoke test across Python 3.9 through 3.13, plus a documentation build check.
 - This changelog.
 
 ### Changed
 - Converted `README.rst` to `README.md` and corrected the version and install URL.
 - Stated the license as the GNU LGPLv3 or later across the README and `setup.py`. pystrix is not dual-licensed. Both `COPYING` and `COPYING.LESSER` ship because the LGPL extends the GPL.
-- Declared Python 3.9+ in `setup.py` through `python_requires` and trove classifiers, and dropped Python 2 and the end-of-life 3.x entries. The classifiers stop at 3.12, because `pystrix/agi/fastagi.py` imports the `cgi` module that Python 3.13 removed (tracked in #36).
+- Declared Python 3.9+ in `setup.py` through `python_requires` and trove classifiers (3.9 through 3.13), and dropped Python 2 and the end-of-life 3.x entries.
 - Narrowed the "any platform" claim. The FastAGI server runs on Linux and macOS only, because it reads `SOMAXCONN` with `sysctl`.
 - Removed the `AUTHORS` file. Provenance now lives in the README, and the contributor list comes from git history and the GitHub contributors page.
 - Modernized `doc/conf.py` (`exclude_patterns`, Read the Docs theme with a fallback, raw-string regex).
 
 ### Fixed
+- Replaced the removed `cgi.urlparse.parse_qs` in `pystrix/agi/fastagi.py` with `urllib.parse.parse_qs`. This fixes FastAGI query-string parsing on all Python 3 and restores Python 3.13 support (#36).
 - `build-release.py` no longer fails on the missing `pystrix.spec`. The RPM packaging path was removed, and the release tarball now ships `README.md` and `CHANGELOG.md` so a build from the sdist can read the long description.
 - Corrected the `_Response.time` description in the AMI docs and fixed several typos.
 - Stopped tracking `doc/_build/` output and macOS `._` metadata files, and fixed the `.gitignore` rule that let them in.

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Communications :: Telephony'
 ]
 


### PR DESCRIPTION
Closes #40

## Summary

The first CI for pystrix. The project had no automated checks, so version-compatibility breaks (like the recent `cgi` removal) went unnoticed until someone hit them at runtime.

## What this adds
- **Test job**: an import smoke check on Python 3.9, 3.10, 3.11, 3.12, and 3.13. It installs the package and imports `pystrix`, `FastAGIServer`, and `Manager`, so it catches import-time compatibility breaks across the supported range. When a real test suite lands, it slots into this job.
- **Docs job**: builds the Sphinx docs with `-W` (warnings as errors), so doc regressions fail the build.

## Related changes
- Re-add the Python 3.13 trove classifier. PR #36 replaced the removed `cgi.urlparse.parse_qs` with `urllib.parse.parse_qs`, so 3.13 works again and the matrix proves it.
- Record the cgi fix and this CI addition in the changelog.

## Security
The workflow interpolates only the fixed `python-version` matrix. It uses no untrusted event inputs (issue or PR titles, bodies, refs), so there is no command-injection surface.

## Verification
- `ci.yml` parses as valid YAML; both jobs and the 3.9-3.13 matrix are present.
- The import smoke command passes locally on 3.11.
- `setup.py` parses with the 3.13 classifier restored.

## Next modernization tracks
Test suite, lint and format (ruff + pre-commit), Python 2 shim removal, and the `pyproject.toml` and SPDX move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)