### PR TITLE
Add an initial pytest unit-test suite

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+source = pystrix
+
+[report]
+show_missing = True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install package
-        run: pip install -e .
-      - name: Import smoke test
-        run: |
-          python -c "import pystrix; from pystrix.agi import FastAGIServer; from pystrix.ami import Manager; print('pystrix', pystrix.VERSION, 'imports on', __import__('sys').version.split()[0])"
+      - name: Install package with test dependencies
+        run: pip install -e '.[test]'
+      - name: Run tests
+        run: pytest -q
 
   docs:
     name: Documentation build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package with test dependencies
         run: pip install -e '.[test]'
-      - name: Run tests
-        run: pytest -q
+      - name: Run tests with coverage
+        run: pytest -q --cov --cov-report=term-missing
 
   docs:
     name: Documentation build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CLAUDE.md` pointing to `AGENTS.md`.
 - A Contributing section and AGI, FastAGI, and AMI quick-start examples in the README.
 - `.readthedocs.yaml` and `doc/requirements.txt` for reproducible documentation builds.
-- A GitHub Actions CI workflow that runs the test suite across Python 3.9 through 3.13, plus a documentation build check.
-- A `pytest` unit-test suite covering AMI message parsing and request building, AGI response parsing, and action and helper formatting, with a `test` extra in `setup.py` (`pip install -e .[test]`).
+- A GitHub Actions CI workflow that runs the test suite with coverage across Python 3.9 through 3.13, plus a documentation build check.
+- A `pytest` unit-test suite covering AMI message parsing and request building, AGI response parsing, and action and helper formatting, with `pytest` and `pytest-cov` in a `test` extra in `setup.py` (`pip install -e '.[test]'`).
+- Coverage measurement through `pytest-cov`, reported in the CI logs. No coverage data leaves CI.
+- A CI status badge in the README.
 - This changelog.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CLAUDE.md` pointing to `AGENTS.md`.
 - A Contributing section and AGI, FastAGI, and AMI quick-start examples in the README.
 - `.readthedocs.yaml` and `doc/requirements.txt` for reproducible documentation builds.
-- A GitHub Actions CI workflow that installs the package and runs an import smoke test across Python 3.9 through 3.13, plus a documentation build check.
+- A GitHub Actions CI workflow that runs the test suite across Python 3.9 through 3.13, plus a documentation build check.
+- A `pytest` unit-test suite covering AMI message parsing and request building, AGI response parsing, and action and helper formatting, with a `test` extra in `setup.py` (`pip install -e .[test]`).
 - This changelog.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pystrix
 
+[![CI](https://github.com/IVRTech/pystrix/actions/workflows/ci.yml/badge.svg)](https://github.com/IVRTech/pystrix/actions/workflows/ci.yml)
+
 **pystrix** is a versatile [Asterisk](https://www.asterisk.org/) interface package for AMI and (Fast)AGI needs. [Ivrnet, inc.](https://www.ivrnet.com/) published it as open source under the LGPLv3, and contributions from all users are welcome.
 
 ## Overview

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ setup(
     platforms=['OS Independent'],
     classifiers=CLASSIFIERS,
     python_requires='>=3.9',
+    extras_require={
+        'test': ['pytest'],
+    },
     packages=[
      'pystrix',
      'pystrix.agi',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     classifiers=CLASSIFIERS,
     python_requires='>=3.9',
     extras_require={
-        'test': ['pytest'],
+        'test': ['pytest', 'pytest-cov'],
     },
     packages=[
      'pystrix',

--- a/tests/test_agi_core.py
+++ b/tests/test_agi_core.py
@@ -1,0 +1,73 @@
+"""Tests for AGI response parsing and helpers (`pystrix.agi.agi_core`)."""
+import pytest
+
+from pystrix.agi.agi_core import (
+    _AGI, _Action, quote,
+    AGIInvalidCommandError, AGIDeadChannelError, AGIResultHangup, AGINoResultError,
+)
+
+
+class _FakeReader:
+    """A minimal stand-in for the read end of the Asterisk pipe."""
+
+    def __init__(self, *lines):
+        self._lines = [line.encode() for line in lines]
+        self._index = 0
+
+    def readline(self):
+        if self._index >= len(self._lines):
+            return b''
+        line = self._lines[self._index]
+        self._index += 1
+        return line
+
+
+def _agi(*lines):
+    # Bypass __init__ so the constructor does not try to read an AGI environment.
+    agi = _AGI.__new__(_AGI)
+    agi._environment = {}
+    agi._rfile = _FakeReader(*lines)
+    return agi
+
+
+def test_parses_success_result():
+    response = _agi('200 result=1\n')._get_result()
+    assert response.code == 200
+    assert response.items['result'].value == '1'
+
+
+def test_parses_result_data():
+    response = _agi('200 result=1 (speech)\n')._get_result()
+    assert response.items['result'].value == '1'
+    assert response.items['result'].data == 'speech'
+
+
+def test_invalid_command_raises():
+    with pytest.raises(AGIInvalidCommandError):
+        _agi('510 Invalid or unknown command\n')._get_result()
+
+
+def test_dead_channel_raises():
+    with pytest.raises(AGIDeadChannelError):
+        _agi('511 Command Not Permitted on a dead channel\n')._get_result()
+
+
+def test_missing_result_key_raises():
+    with pytest.raises(AGINoResultError):
+        _agi('200 foo=bar\n')._get_result()
+
+
+def test_hangup_result_raises():
+    with pytest.raises(AGIResultHangup):
+        _agi('200 result=-1 (hangup)\n')._get_result()
+
+
+def test_action_command_formatting():
+    assert _Action('ANSWER').command == 'ANSWER\n'
+    # None arguments are dropped and a trailing newline is always present.
+    assert _Action('STREAM FILE', 'demo', None, '#').command == 'STREAM FILE demo #\n'
+
+
+def test_quote_wraps_in_double_quotes():
+    assert quote('demo') == '"demo"'
+    assert quote(5) == '"5"'

--- a/tests/test_agi_core.py
+++ b/tests/test_agi_core.py
@@ -4,6 +4,7 @@ import pytest
 from pystrix.agi.agi_core import (
     _AGI, _Action, quote,
     AGIInvalidCommandError, AGIDeadChannelError, AGIResultHangup, AGINoResultError,
+    AGIUsageError, AGIUnknownError,
 )
 
 
@@ -40,6 +41,49 @@ def test_parses_result_data():
     response = _agi('200 result=1 (speech)\n')._get_result()
     assert response.items['result'].value == '1'
     assert response.items['result'].data == 'speech'
+
+
+def test_result_without_parenthetical_has_empty_data():
+    # A result with no parenthetical reports data as '' (empty string), not None.
+    response = _agi('200 result=1\n')._get_result()
+    assert response.items['result'].data == ''
+
+
+def test_usage_error_collects_multiline_block():
+    # The 520 path reads lines until '520 End of proper usage.' and raises with
+    # the accumulated block.
+    with pytest.raises(AGIUsageError) as exc_info:
+        _agi(
+            '520 Invalid command syntax.\n',
+            'Usage: ANSWER\n',
+            '520 End of proper usage.\n',
+        )._get_result()
+    message = str(exc_info.value)
+    assert '520 Invalid command syntax.' in message
+    assert 'Usage: ANSWER' in message
+
+
+def test_unrecognized_code_returns_none():
+    # A line with no leading status code (for example after a signal) yields no
+    # result rather than raising.
+    assert _agi('\n')._get_result() is None
+
+
+def test_unknown_code_raises():
+    with pytest.raises(AGIUnknownError):
+        _agi('418 unexpected\n')._get_result()
+
+
+def test_hangup_detected_by_data_not_value():
+    # The hangup guard keys on the parenthetical data, not the result value, so a
+    # non-(-1) value with 'hangup' data must still raise.
+    with pytest.raises(AGIResultHangup):
+        _agi('200 result=0 (hangup)\n')._get_result()
+
+
+def test_hangup_not_raised_when_check_disabled():
+    response = _agi('200 result=-1 (hangup)\n')._get_result(check_hangup=False)
+    assert response.items['result'].data == 'hangup'
 
 
 def test_invalid_command_raises():

--- a/tests/test_ami_message.py
+++ b/tests/test_ami_message.py
@@ -20,6 +20,11 @@ def test_name_prefers_event_then_response():
     assert _message('Response: Success').name == 'Success'
 
 
+def test_name_prefers_event_when_both_present():
+    # `name` is Event or Response, so Event wins when a message carries both.
+    assert _message('Event: Hangup', 'Response: Success').name == 'Hangup'
+
+
 def test_equality_against_string_uses_name():
     assert _message('Event: Hangup') == 'Hangup'
 
@@ -28,6 +33,29 @@ def test_data_payload_follows_headers():
     message = _message('Response: Follows', 'raw output line without a colon')
     assert message['Response'] == 'Follows'
     assert message.data == ['raw output line without a colon']
+
+
+def test_data_mode_is_sticky_for_later_colon_lines():
+    # Once a data line is seen, later colon-bearing lines stay data and are not
+    # parsed as headers.
+    message = _message('Response: Follows', 'first data line', 'Looks: like-a-header')
+    assert message['Response'] == 'Follows'
+    assert message.data == ['first data line', 'Looks: like-a-header']
+    assert 'Looks' not in message
+
+
+def test_fake_eol_line_starts_data_section():
+    # A line ending in the fake-EOL pattern marks the start of the data section.
+    message = _Message(['Response: Follows\r\n', 'payload\n\r\n'])
+    assert message['Response'] == 'Follows'
+    assert message.data == ['payload']
+
+
+def test_non_crlf_line_starts_data_section():
+    # A line not terminated by CRLF is treated as data, not a header.
+    message = _Message(['Response: Follows\r\n', 'payload\n'])
+    assert message['Response'] == 'Follows'
+    assert message.data == ['payload']
 
 
 def test_generic_response_when_only_action_id():

--- a/tests/test_ami_message.py
+++ b/tests/test_ami_message.py
@@ -1,0 +1,40 @@
+"""Tests for AMI message parsing (`pystrix.ami.ami._Message`)."""
+from pystrix.ami.ami import _Message, RESPONSE_GENERIC, EVENT_GENERIC
+
+
+def _message(*lines):
+    # Asterisk sends CRLF-terminated lines, which `read_message` collects into a
+    # list before constructing a `_Message`. Reproduce that here.
+    return _Message([line + '\r\n' for line in lines])
+
+
+def test_parses_headers():
+    message = _message('Response: Success', 'ActionID: abc-1')
+    assert message['Response'] == 'Success'
+    assert message['ActionID'] == 'abc-1'
+    assert message.action_id == 'abc-1'
+
+
+def test_name_prefers_event_then_response():
+    assert _message('Event: Hangup', 'ActionID: 1').name == 'Hangup'
+    assert _message('Response: Success').name == 'Success'
+
+
+def test_equality_against_string_uses_name():
+    assert _message('Event: Hangup') == 'Hangup'
+
+
+def test_data_payload_follows_headers():
+    message = _message('Response: Follows', 'raw output line without a colon')
+    assert message['Response'] == 'Follows'
+    assert message.data == ['raw output line without a colon']
+
+
+def test_generic_response_when_only_action_id():
+    # A reply with an ActionID but no Response header is salvaged as generic.
+    assert _message('ActionID: 7')['Response'] == RESPONSE_GENERIC
+
+
+def test_generic_event_when_unsolicited():
+    # A message with neither Response, Event, nor ActionID is a generic event.
+    assert _message('Foo: bar')['Event'] == EVENT_GENERIC

--- a/tests/test_ami_request.py
+++ b/tests/test_ami_request.py
@@ -1,4 +1,6 @@
 """Tests for AMI request building (`pystrix.ami.ami._Request`)."""
+import pytest
+
 from pystrix.ami.ami import _Request
 
 
@@ -33,6 +35,37 @@ def test_multi_value_header_expands_to_repeated_lines():
     assert 'Variable: b=2\r\n' in command
 
 
+def test_multi_value_order_preserved_and_blank_line_terminator():
+    request = _Request('Originate')
+    request['Variable'] = ('a=1', 'b=2')
+    command, _ = _build(request)
+    assert command.index('Variable: a=1') < command.index('Variable: b=2')
+    assert command.endswith('\r\n\r\n')
+
+
 def test_kwargs_become_headers():
     command, _ = _build(_Request('Ping'), Extra='x')
     assert 'Extra: x' in command
+
+
+# The two cases below encode build_request's documented ActionID contract.
+# The implementation currently violates it (see issue #43): a pre-set ActionID
+# is dropped when action_id is None, and it overrides an explicit action_id.
+# These are strict xfails, so they will fail loudly once #43 is fixed, prompting
+# removal of the markers.
+@pytest.mark.xfail(reason="build_request drops a pre-set ActionID; see #43", strict=True)
+def test_preset_action_id_used_when_none_passed():
+    request = _Request('Ping')
+    request['ActionID'] = 'preset'
+    command, action_id = _build(request)
+    assert action_id == 'preset'
+    assert 'ActionID: preset' in command
+
+
+@pytest.mark.xfail(reason="explicit action_id loses to a pre-set ActionID; see #43", strict=True)
+def test_explicit_action_id_wins_over_preset():
+    request = _Request('Ping')
+    request['ActionID'] = 'preset'
+    command, action_id = _build(request, action_id='explicit')
+    assert action_id == 'explicit'
+    assert 'ActionID: explicit' in command

--- a/tests/test_ami_request.py
+++ b/tests/test_ami_request.py
@@ -1,0 +1,38 @@
+"""Tests for AMI request building (`pystrix.ami.ami._Request`)."""
+from pystrix.ami.ami import _Request
+
+
+def _build(request, action_id=None, **kwargs):
+    return request.build_request(action_id, lambda: 'GEN-1', **kwargs)
+
+
+def test_generates_action_id_when_absent():
+    command, action_id = _build(_Request('Ping'))
+    assert action_id == 'GEN-1'
+    assert command == 'Action: Ping\r\nActionID: GEN-1\r\n\r\n'
+
+
+def test_uses_explicit_action_id():
+    command, action_id = _build(_Request('Ping'), action_id='custom')
+    assert action_id == 'custom'
+    assert 'ActionID: custom' in command
+
+
+def test_action_is_always_the_first_line():
+    request = _Request('Login')
+    request['Username'] = 'admin'
+    command, _ = _build(request)
+    assert command.startswith('Action: Login\r\n')
+
+
+def test_multi_value_header_expands_to_repeated_lines():
+    request = _Request('Originate')
+    request['Variable'] = ('a=1', 'b=2')
+    command, _ = _build(request)
+    assert 'Variable: a=1\r\n' in command
+    assert 'Variable: b=2\r\n' in command
+
+
+def test_kwargs_become_headers():
+    command, _ = _build(_Request('Ping'), Extra='x')
+    assert 'Extra: x' in command

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -9,7 +9,10 @@ def test_package_imports():
 def test_public_entry_points_import():
     from pystrix.agi import AGI, FastAGIServer, FastAGI
     from pystrix.ami import Manager
+    from pystrix.agi.fastagi import FastAGIServer as _FastAGIServer
 
-    # Importing FastAGIServer exercises pystrix/agi/fastagi.py, which must not
-    # pull in the cgi module that Python 3.13 removed.
-    assert AGI and FastAGIServer and FastAGI and Manager
+    # The re-export must be the same class object, and importing fastagi
+    # exercises the code path that has to stay free of the cgi module removed in
+    # Python 3.13.
+    assert FastAGIServer is _FastAGIServer
+    assert isinstance(AGI, type) and isinstance(FastAGI, type) and isinstance(Manager, type)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,15 @@
+"""Import smoke tests that double as a cross-version compatibility check."""
+
+
+def test_package_imports():
+    import pystrix
+    assert pystrix.VERSION
+
+
+def test_public_entry_points_import():
+    from pystrix.agi import AGI, FastAGIServer, FastAGI
+    from pystrix.ami import Manager
+
+    # Importing FastAGIServer exercises pystrix/agi/fastagi.py, which must not
+    # pull in the cgi module that Python 3.13 removed.
+    assert AGI and FastAGIServer and FastAGI and Manager


### PR DESCRIPTION
Closes #41

## Summary

The first test suite for pystrix. The project had no automated tests, so the parsing and request-building core was unverified. These unit tests cover the parts that run without a live Asterisk server, and the CI test job now runs them across Python 3.9 through 3.13.

## What this adds
- **AMI message parsing** (`tests/test_ami_message.py`): header and CRLF framing, data payloads, and the generic-response and generic-event salvage paths in `_Message`.
- **AMI request building** (`tests/test_ami_request.py`): ActionID generation and reuse, action-line ordering, multi-value headers, and keyword headers in `_Request.build_request`.
- **AGI response parsing** (`tests/test_agi_core.py`): the 200, 510, 511, missing-result, and hangup paths in `_AGI._get_result`, plus `_Action.command` formatting and `quote`.
- **Import smoke** (`tests/test_import.py`): loads the full package and the FastAGI and AMI entry points, so the cross-version compatibility check now lives in the suite.

## Packaging and CI
- A `test` extra in `setup.py` (`pytest` and `pytest-cov`), installed with `pip install -e '.[test]'`.
- The CI test job runs `pytest` instead of the previous import-only smoke step, across the full 3.9 to 3.13 matrix.

## Coverage and badges
- `pytest-cov` measures coverage and prints a `term-missing` report in the CI logs. A `.coveragerc` scopes it to the `pystrix` package. Baseline is 43%.
- No coverage data leaves CI. Hosted or third-party coverage badges were declined for data privacy, since the repository is organization-managed.
- A GitHub Actions CI status badge was added to the README.

## Verification
- 21 tests pass locally on Python 3.11, with coverage reported.
- `ci.yml` parses as valid YAML.

## Review panel
Reviewed by codex (independent) and pr-test-analyzer. The suite was found correct and well-structured; findings were coverage gaps, now addressed: the AGI 520 / unrecognized-code / unknown-code / hangup-by-data / check_hangup paths, AMI message data-mode framing and Event-over-Response precedence, and multi-value header ordering. The import smoke assert was strengthened to an identity check.

The review also surfaced a real bug: `build_request` mishandles a pre-set `ActionID`, contradicting its docstring. It is tracked in #43 and guarded here by strict `xfail` tests that will flip when #43 is fixed.

Suite is now 32 passed, 2 xfailed (the #43 guards).

## Next modernization tracks
Lint and format (ruff and pre-commit), Python 2 shim removal, and the pyproject.toml and SPDX move. A coverage threshold gate is a possible later addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


