### PR TITLE
Fix build_request ActionID precedence (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Modernized `doc/conf.py` (`exclude_patterns`, Read the Docs theme with a fallback, raw-string regex).
 
 ### Fixed
-- `_Request.build_request` now honors its documented ActionID precedence: an explicit argument wins, then a value already set on the request, then a generated one. Previously a pre-set ActionID was dropped when no argument was passed, and it overrode an explicit argument (#43).
+- `_Request.build_request` now honors its documented ActionID precedence: an explicit argument wins, then a value already set on the request, then a generated one. Previously a pre-set ActionID was dropped when no argument was passed, and it overrode an explicit argument. The resolved ActionID is also coerced to a string so a pre-set non-string value matches Asterisk's responses (#43).
 - Replaced the removed `cgi.urlparse.parse_qs` in `pystrix/agi/fastagi.py` with `urllib.parse.parse_qs`. This fixes FastAGI query-string parsing on all Python 3 and restores Python 3.13 support (#36).
 - `build-release.py` no longer fails on the missing `pystrix.spec`. The RPM packaging path was removed, and the release tarball now ships `README.md` and `CHANGELOG.md` so a build from the sdist can read the long description.
 - Corrected the `_Response.time` description in the AMI docs and fixed several typos.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Modernized `doc/conf.py` (`exclude_patterns`, Read the Docs theme with a fallback, raw-string regex).
 
 ### Fixed
+- `_Request.build_request` now honors its documented ActionID precedence: an explicit argument wins, then a value already set on the request, then a generated one. Previously a pre-set ActionID was dropped when no argument was passed, and it overrode an explicit argument (#43).
 - Replaced the removed `cgi.urlparse.parse_qs` in `pystrix/agi/fastagi.py` with `urllib.parse.parse_qs`. This fixes FastAGI query-string parsing on all Python 3 and restores Python 3.13 support (#36).
 - `build-release.py` no longer fails on the missing `pystrix.spec`. The RPM packaging path was removed, and the release tarball now ships `README.md` and `CHANGELOG.md` so a build from the sdist can read the long description.
 - Corrected the `_Response.time` description in the AMI docs and fixed several typos.

--- a/pystrix/ami/ami.py
+++ b/pystrix/ami/ami.py
@@ -915,12 +915,11 @@ class _Request(dict):
             else:
                 items.append((key, str(value)))
 
-        if action_id or not KEY_ACTIONID in self: #Replace or add an ActionID, if necessary
-            if not action_id:
-                action_id = str(id_generator())
-            elif KEY_ACTIONID in self:
-                action_id = self[KEY_ACTIONID]
-            items.append((KEY_ACTIONID, action_id))
+        #Resolve the ActionID using the precedence documented above: an explicit
+        #argument wins, then any value already set on the request, then a generated one.
+        if not action_id:
+            action_id = self.get(KEY_ACTIONID) or str(id_generator())
+        items.append((KEY_ACTIONID, action_id))
             
         return (
          _EOL.join(['%(key)s: %(value)s' % {

--- a/pystrix/ami/ami.py
+++ b/pystrix/ami/ami.py
@@ -514,7 +514,7 @@ class Manager(object):
         if not self.is_connected():
             raise ManagerError("Not connected to an Asterisk manager")
             
-        (command, action_id) = request.build_request(action_id and str(action_id), self._get_host_action_id, **kwargs)
+        (command, action_id) = request.build_request(None if action_id is None else str(action_id), self._get_host_action_id, **kwargs)
         events = self._add_outstanding_request(action_id, request)
         with self._connection_lock:
             self._connection.send_message(command)
@@ -916,9 +916,12 @@ class _Request(dict):
                 items.append((key, str(value)))
 
         #Resolve the ActionID using the precedence documented above: an explicit
-        #argument wins, then any value already set on the request, then a generated one.
-        if not action_id:
-            action_id = self.get(KEY_ACTIONID) or str(id_generator())
+        #argument wins, then any value already set on the request, then a generated
+        #one. Fall back only when the argument is None, not merely falsy, and coerce
+        #to a string so it matches the string-keyed responses Asterisk sends back.
+        if action_id is None:
+            action_id = self[KEY_ACTIONID] if KEY_ACTIONID in self else id_generator()
+        action_id = str(action_id)
         items.append((KEY_ACTIONID, action_id))
             
         return (

--- a/tests/test_ami_request.py
+++ b/tests/test_ami_request.py
@@ -63,3 +63,13 @@ def test_explicit_action_id_wins_over_preset():
     command, action_id = _build(request, action_id='explicit')
     assert action_id == 'explicit'
     assert 'ActionID: explicit' in command
+
+
+def test_non_string_action_id_is_stringified():
+    # A non-string ActionID must be returned as a string so it matches the
+    # string-keyed responses Asterisk sends back (see #43 review).
+    request = _Request('Ping')
+    request['ActionID'] = 7
+    command, action_id = _build(request)
+    assert action_id == '7'
+    assert 'ActionID: 7' in command

--- a/tests/test_ami_request.py
+++ b/tests/test_ami_request.py
@@ -1,6 +1,4 @@
 """Tests for AMI request building (`pystrix.ami.ami._Request`)."""
-import pytest
-
 from pystrix.ami.ami import _Request
 
 
@@ -48,12 +46,9 @@ def test_kwargs_become_headers():
     assert 'Extra: x' in command
 
 
-# The two cases below encode build_request's documented ActionID contract.
-# The implementation currently violates it (see issue #43): a pre-set ActionID
-# is dropped when action_id is None, and it overrides an explicit action_id.
-# These are strict xfails, so they will fail loudly once #43 is fixed, prompting
-# removal of the markers.
-@pytest.mark.xfail(reason="build_request drops a pre-set ActionID; see #43", strict=True)
+# build_request resolves the ActionID with the precedence documented on the
+# method: an explicit argument wins, then a value already set on the request,
+# then a generated one (fixed in #43).
 def test_preset_action_id_used_when_none_passed():
     request = _Request('Ping')
     request['ActionID'] = 'preset'
@@ -62,7 +57,6 @@ def test_preset_action_id_used_when_none_passed():
     assert 'ActionID: preset' in command
 
 
-@pytest.mark.xfail(reason="explicit action_id loses to a pre-set ActionID; see #43", strict=True)
 def test_explicit_action_id_wins_over_preset():
     request = _Request('Ping')
     request['ActionID'] = 'preset'


### PR DESCRIPTION
Closes #43

## Summary

`_Request.build_request` contradicted its own docstring when a request carried a pre-set `ActionID`. The docstring says the `action_id` argument is "the Asterisk ActionID to use, or None to use whatever is in the request, if anything, or the output of id_generator if not." The code did neither correctly:

- With `action_id=None` and a pre-set `request['ActionID']`, the ActionID was dropped entirely. The command carried no ActionID and `None` was returned.
- With an explicit `action_id` and a pre-set `request['ActionID']`, the pre-set value overrode the explicit argument.

## Fix

Resolve the ActionID with the documented precedence: an explicit argument wins, then a value already set on the request, then a generated one. Fall back only when the argument is `None` (not merely falsy), and coerce the result to a string. Every request still receives an ActionID.

```python
if action_id is None:
    action_id = self[KEY_ACTIONID] if KEY_ACTIONID in self else id_generator()
action_id = str(action_id)
items.append((KEY_ACTIONID, action_id))
```

`Manager.send_action` now passes `None if action_id is None else str(action_id)` so an explicit falsy id is not collapsed to a fallback.

## Codex review

Reviewed by codex (independent model), verdict merge-with-fixes, both applied:

- Fall back on `None`, not on any falsy value, so an explicit `''` or `0` is honored per the docstring.
- Coerce the resolved ActionID to a string. A pre-set non-string value (for example an int) reached the wire as a string but was returned unnormalized, so `send_action`'s lookup could not match Asterisk's string-keyed response and the request would time out.

## Tests

The two strict `xfail` guards added in #42 now pass and become normal regression tests, plus a string-coercion regression test. Cases covered and verified:

| action_id arg | pre-set ActionID | result |
| --- | --- | --- |
| none | none | generated |
| explicit | none | explicit |
| none | preset | preset (stringified) |
| explicit | preset | explicit |
| none | preset int `7` | returned `'7'` |

Suite: 35 passed (was 32 passed + 2 xfailed before this branch).

## Risk

Low. Requests rarely carry a pre-set ActionID, and `Manager.send_action` passes an explicit id, so the common paths (generated, explicit-without-preset) are unchanged. Only the previously-broken pre-set paths change behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

