### PR TITLE
Add ruff linting and pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff
+        run: pip install ruff==0.15.19
+      - name: Run ruff
+        run: ruff check .
+
   test:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# Pre-commit hooks for pystrix. Run `pre-commit install` once to enable, then
+# the hooks run on each commit. See https://pre-commit.com.
+#
+# Formatting hooks are intentionally omitted for now (see issue #45); ruff is
+# used for linting only until a dedicated formatting pass.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.19
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - A `pytest` unit-test suite covering AMI message parsing and request building, AGI response parsing, and action and helper formatting, with `pytest` and `pytest-cov` in a `test` extra in `setup.py` (`pip install -e '.[test]'`).
 - Coverage measurement through `pytest-cov`, reported in the CI logs. No coverage data leaves CI.
 - A CI status badge in the README.
+- A curated `ruff` lint configuration (`ruff.toml`), a `.pre-commit-config.yaml`, and a CI lint job. Linting only for now; formatting is deferred.
 - This changelog.
 
 ### Changed
@@ -26,6 +27,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Modernized `doc/conf.py` (`exclude_patterns`, Read the Docs theme with a fallback, raw-string regex).
 
 ### Fixed
+- Applied safe lint fixes surfaced by ruff: `not x is`/`not x in` rewritten to `x is not`/`x not in`, removed unused imports, and turned two invalid escape sequences (`\d`, `\*`) into raw strings. The Python 2 shims and intentional re-exports are marked with targeted ignores.
 - `_Request.build_request` now honors its documented ActionID precedence: an explicit argument wins, then a value already set on the request, then a generated one. Previously a pre-set ActionID was dropped when no argument was passed, and it overrode an explicit argument. The resolved ActionID is also coerced to a string so a pre-set non-string value matches Asterisk's responses (#43).
 - Replaced the removed `cgi.urlparse.parse_qs` in `pystrix/agi/fastagi.py` with `urllib.parse.parse_qs`. This fixes FastAGI query-string parsing on all Python 3 and restores Python 3.13 support (#36).
 - `build-release.py` no longer fails on the missing `pystrix.spec`. The RPM packaging path was removed, and the release tarball now ships `README.md` and `CHANGELOG.md` so a build from the sdist can read the long description.

--- a/README.md
+++ b/README.md
@@ -112,16 +112,17 @@ pystrix has no third-party runtime dependencies, so setup is short.
 git clone https://github.com/IVRTech/pystrix.git
 cd pystrix
 python3 -m venv .venv && source .venv/bin/activate
-pip install -e .
+pip install -e '.[test]'
 ```
 
 The editable install (`-e`) means your local edits take effect without reinstalling.
 
 A few things to know before you send a change:
 
-- **No test suite.** The project has no automated tests and no CI. Verify your change by running the matching example in `doc/examples/` against a live Asterisk server. AMI listens on port 5038 and FastAGI on port 4573.
+- **Run the tests** with `pytest`. CI runs them across Python 3.9 through 3.13 on every pull request. There is no live-Asterisk integration test, so socket-level behavior is still worth checking against a real server (AMI on port 5038, FastAGI on port 4573).
+- **Lint with ruff.** `ruff check .` must pass, and CI enforces it. Install the hooks to lint on each commit: `pip install pre-commit && pre-commit install`. Formatting is not enforced yet.
 - **Target Python 3.9+.** The codebase still carries Python 2 compatibility shims (the `Queue` import fallback, `basestring` checks). These are being removed during modernization, so don't add new ones.
-- **Build the docs** when you touch them: `pip install sphinx`, then `cd doc && make html`.
+- **Build the docs** when you touch them: `pip install -r doc/requirements.txt`, then `cd doc && make html`.
 - **Version bumps** go in `pystrix/__init__.py`. `setup.py` reads `VERSION` from there.
 - **Keep docstrings complete** and written in reStructuredText. The reference docs are generated from them.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-import sys, os, re
+import sys
+import os
+import re
 
 sys.path.append(os.path.abspath('..'))
 import pystrix as module

--- a/pystrix/agi/agi_core.py
+++ b/pystrix/agi/agi_core.py
@@ -36,7 +36,6 @@ Authors:
 """
 import collections
 import re
-import time
 
 import sys
 
@@ -148,7 +147,7 @@ class _AGI(object):
             for (key, value, data) in _RE_KV.findall(m.group(2)):
                 response[key] = _ValueData(value or '', data)
                 
-            if not _RESULT_KEY in response: #Must always be present.
+            if _RESULT_KEY not in response: #Must always be present.
                 raise AGINoResultError("Asterisk did not provide a '%(result-key)s' key-value pair" % {
                  'result-key': _RESULT_KEY,
                 }, response)
@@ -208,7 +207,7 @@ class _AGI(object):
             line = self._rfile.readline()
             try:
                 line = line.decode()  # decode line if it comes in bytes, example if it comes from a socket
-            except:
+            except:  # noqa: E722
                 pass  # line it's a string, so nothing to change - it's string if it's using stdin as _rfile for example
             # Check to see if we received a HANGUP because AGISIGHUP was not set explicitly or is no
             # and then handle the HANGUP which is being returned because the AGI script can still interact with
@@ -271,7 +270,7 @@ class _Action(object):
 
     @property
     def command(self):
-        command = ' '.join([self._command.strip()] + [str(arg) for arg in self._arguments if not arg is None]).strip()
+        command = ' '.join([self._command.strip()] + [str(arg) for arg in self._arguments if arg is not None]).strip()
         if not command.endswith('\n'):
             command += '\n'
         return command

--- a/pystrix/ami/ami.py
+++ b/pystrix/ami/ami.py
@@ -44,7 +44,7 @@ import warnings
 
 try:
     import queue
-except:
+except:  # noqa: E722
     import Queue as queue
 
 from pystrix.ami import generic_transforms
@@ -835,8 +835,8 @@ class _Message(_MessageTemplate, dict):
         """
         while response:
             line = response[0]
-            if line.endswith(_EOL_FAKE) or not line.endswith(_EOL) or not ':' in line: #All lines from this point forth are data
-                self.data.extend((l.strip() for l in response))
+            if line.endswith(_EOL_FAKE) or not line.endswith(_EOL) or ':' not in line: #All lines from this point forth are data
+                self.data.extend((entry.strip() for entry in response))
                 break
             (key, value) = response.pop(0).split(':', 1)
             self[key.strip()] = value.strip()
@@ -907,7 +907,7 @@ class _Request(dict):
         The 'Action' line is always first.
         """
         items = [(KEY_ACTION, self[KEY_ACTION])]
-        for (key, value) in [(k, v) for (k, v) in self.items() if not k in (KEY_ACTION, KEY_ACTIONID)] + list(kwargs.items()):
+        for (key, value) in [(k, v) for (k, v) in self.items() if k not in (KEY_ACTION, KEY_ACTIONID)] + list(kwargs.items()):
             key = str(key)
             if type(value) in (tuple, list, set, frozenset):
                 for val in value:
@@ -1088,7 +1088,7 @@ class _SynchronisedSocket(object):
         if self._socket_write_lock is None:
             self._close()
             return
-        with self._socket_write_lock as write_lock:
+        with self._socket_write_lock:
             self._close()
             
     def _close(self):

--- a/pystrix/ami/app_confbridge.py
+++ b/pystrix/ami/app_confbridge.py
@@ -34,10 +34,9 @@ Authors:
 The requests and events implemented by this module follow the definitions provided by
 https://wiki.asterisk.org/
 """
-from pystrix.ami.ami import (_Request, ManagerError)
+from pystrix.ami.ami import (_Request)
 from pystrix.ami import core_events
 from pystrix.ami import app_confbridge_events
-from pystrix.ami import generic_transforms
 
 class ConfbridgeKick(_Request):
     """

--- a/pystrix/ami/app_meetme.py
+++ b/pystrix/ami/app_meetme.py
@@ -34,9 +34,8 @@ Authors:
 The requests and events implemented by this module follow the definitions provided by
 http://www.asteriskdocs.org/ and https://wiki.asterisk.org/
 """
-from pystrix.ami.ami import (_Request, ManagerError)
+from pystrix.ami.ami import (_Request)
 from pystrix.ami import app_meetme_events
-from pystrix.ami import generic_transforms
 
 class MeetmeList(_Request):
     """
@@ -56,7 +55,7 @@ class MeetmeList(_Request):
         `conference` is the optional identifier of the bridge.
         """
         _Request.__init__(self, 'MeetmeList')
-        if not conference is None:
+        if conference is not None:
             self['Conference'] = conference
             
 class MeetmeListRooms(_Request):

--- a/pystrix/ami/core.py
+++ b/pystrix/ami/core.py
@@ -39,7 +39,6 @@ http://www.asteriskdocs.org/ and https://wiki.asterisk.org/
 """
 import hashlib
 import time
-import types
 
 from pystrix.ami.ami import (_Request, ManagerError)
 from pystrix.ami import core_events
@@ -124,7 +123,7 @@ class AGI(_Request):
         _Request.__init__(self, 'AGI')
         self['Channel'] = channel
         self['Command'] = command
-        if not command_id is None:
+        if command_id is not None:
             self['CommandID'] = str(command_id)
 
 class Bridge(_Request):
@@ -244,7 +243,7 @@ class DBDelTree(_Request):
         """
         _Request.__init__(self, 'DBDelTree')
         self['Family'] = family
-        if not key is None:
+        if key is not None:
             self['Key'] = key
             
 class DBGet(_Request):
@@ -380,7 +379,7 @@ class Getvar(_Request):
         """
         _Request.__init__(self, 'Getvar')
         self['Variable'] = variable
-        if not channel is None:
+        if channel is not None:
             self['Channel'] = channel
             
 class Hangup(_Request):
@@ -455,7 +454,7 @@ class Login(_Request):
         _Request.__init__(self, 'Login')
         self['Username'] = username
         
-        if not challenge is None and authtype:
+        if challenge is not None and authtype:
             self['AuthType'] = authtype
             if authtype == AUTHTYPE_MD5:
                 self['Key'] = hashlib.md5(
@@ -589,7 +588,7 @@ class ModuleLoad(_Request):
         """
         _Request.__init__(self, 'ModuleLoad')
         self['LoadType'] = load_type
-        if not module is None:
+        if module is not None:
             self['Module'] = module
             
 class Monitor(_Request):
@@ -909,11 +908,11 @@ class QueueLog(_Request):
         _Request.__init__(self, "QueueLog")
         self['Queue'] = queue
         self['Event'] = event
-        if not uniqueid is None:
+        if uniqueid is not None:
             self['Uniqueid'] = uniqueid
-        if not interface is None:
+        if interface is not None:
             self['Interface'] = interface
-        if not message is None:
+        if message is not None:
             self['Message'] = message
 
 class QueuePause(_Request):
@@ -932,7 +931,7 @@ class QueuePause(_Request):
         _Request.__init__(self, "QueuePause")
         self['Interface'] = interface
         self['Paused'] = paused and 'true' or 'false'
-        if not queue is None:
+        if queue is not None:
             self['Queue'] = queue
 
 class QueuePenalty(_Request):
@@ -949,7 +948,7 @@ class QueuePenalty(_Request):
         _Request.__init__(self, "QueuePenalty")
         self['Interface'] = interface
         self['Penalty'] = str(penalty)
-        if not queue is None:
+        if queue is not None:
             self['Queue'] = queue
 
 class QueueReload(_Request):
@@ -973,7 +972,7 @@ class QueueReload(_Request):
         self['Members'] = members
         self['Rules'] = rules
         self['Parameters'] = parameters
-        if not queue is None:
+        if queue is not None:
             self['Queue'] = queue
             
 class QueueRemove(_Request):
@@ -1010,7 +1009,7 @@ class QueueStatus(_Request):
         Describes all queues in the system, unless `queue` is given, which limits the scope to one.
         """
         _Request.__init__(self, "QueueStatus")
-        if not queue is None:
+        if queue is not None:
             self['Queue'] = queue
 
          
@@ -1030,7 +1029,7 @@ class QueueSummary(_Request):
         Describes all queues in the system, unless `queue` is given, which limits the scope to one.
         """
         _Request.__init__(self, "QueueSummary")
-        if not queue is None:
+        if queue is not None:
             self['Queue'] = queue
           
           
@@ -1066,7 +1065,7 @@ class Reload(_Request):
         extension.
         """
         _Request.__init__(self, "Reload")
-        if not module is None:
+        if module is not None:
             self['Module'] = module
 
 class SendText(_Request):
@@ -1164,7 +1163,7 @@ class SIPqualify(_Request):
         self['Peer'] = peer
 
 class SIPshowpeer(_Request):
-    """
+    r"""
     Provides detailed information about a SIP peer.
 
     The response has the following key-value pairs:
@@ -1340,7 +1339,7 @@ class UpdateConfig(_Request):
         _Request.__init__(self, "UpdateConfig")
         self['SrcFilename'] = src_filename
         self['DstFilename'] = dst_filename
-        self['Reload'] = type(reload) == bool and (reload and 'true' or 'false') or reload
+        self['Reload'] = type(reload) == bool and (reload and 'true' or 'false') or reload  # noqa: E721
 
         for (i, (action, category, variable, value, match)) in enumerate(changes):
             index = '%(index)06i' % {
@@ -1348,11 +1347,11 @@ class UpdateConfig(_Request):
             }
             self['Action-' + index] = action
             self['Cat-' + index] = category
-            if not variable is None:
+            if variable is not None:
                 self['Var-' + index] = variable
-            if not value is None:
+            if value is not None:
                 self['Value-' + index] = value
-            if not match is None:
+            if match is not None:
                 self['Match-' + index] = match
 
 class UserEvent(_Request):

--- a/pystrix/ami/core_events.py
+++ b/pystrix/ami/core_events.py
@@ -803,7 +803,7 @@ class StatusComplete(_Event):
         return (headers, data)
 
 class UserEvent(_Event):
-    """
+    r"""
     Generated in response to the UserEvent request.
     
     - \*: Any key-value pairs supplied with the request, as strings

--- a/pystrix/ami/dahdi.py
+++ b/pystrix/ami/dahdi.py
@@ -33,9 +33,8 @@ Authors:
 The requests implemented by this module follow the definitions provided by
 https://wiki.asterisk.org/
 """
-from pystrix.ami.ami import (_Request, ManagerError)
+from pystrix.ami.ami import (_Request)
 from pystrix.ami import dahdi_events
-from pystrix.ami import generic_transforms
 
 class DAHDIDNDoff(_Request):
     """
@@ -100,6 +99,6 @@ class DAHDIShowChannels(_Request):
     
     def __init__(self, dahdi_channel=None):
         _Request.__init__(self, 'DAHDIShowChannels')
-        if not dahdi_channel is None:
+        if dahdi_channel is not None:
             self['DAHDIChannel'] = dahdi_channel
             

--- a/pystrix/ami/generic_transforms.py
+++ b/pystrix/ami/generic_transforms.py
@@ -32,7 +32,7 @@ import sys
 
 
 # identify string type in a python 2 and 3 compatible manner
-string_type = str if sys.version_info[0] >= 3 else basestring
+string_type = str if sys.version_info[0] >= 3 else basestring  # noqa: F821
 
 
 def to_bool(dictionary, keys, truth_value=None, truth_function=(lambda x:bool(x)), preprocess=(lambda x:x)):

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,21 @@
+# Lint configuration for pystrix.
+#
+# Formatting is intentionally not enabled yet (see issue #45): the existing
+# style is non-standard and `ruff format` would rewrite ~4,000 lines. A later
+# pass, paired with the Python 2 shim removal, will own formatting. When the
+# project moves to pyproject.toml, this config can move there.
+target-version = "py39"
+
+[lint]
+# pycodestyle errors/warnings and pyflakes, minus the whitespace, indentation,
+# and line-length families that a formatting pass will own.
+select = ["E4", "E7", "E9", "F", "W605"]
+
+[lint.per-file-ignores]
+# The __init__ modules deliberately re-export their public API.
+"pystrix/__init__.py" = ["F401"]
+"pystrix/agi/__init__.py" = ["F401"]
+"pystrix/ami/__init__.py" = ["F401"]
+# The AGI wrapper modules intentionally star-import the shared core.
+"pystrix/agi/agi.py" = ["F403", "F405"]
+"pystrix/agi/fastagi.py" = ["F403", "F405"]


### PR DESCRIPTION
Closes #45

## Summary

Adds ruff linting and pre-commit hooks, wired into CI. Lint-only: `ruff format` would rewrite ~4,000 lines across all 21 files because the existing style is non-standard, so formatting is deferred to a later pass that pairs with the Python 2 shim removal. git blame stays intact.

## Configuration
- `ruff.toml` with a curated rule set: `E4`, `E7`, `E9`, `F`, and `W605`. The whitespace and line-length families are left out (a formatting pass will own them).
- Per-file ignores for intentional patterns: the public re-exports in the `__init__` modules (`F401`) and the AGI star imports (`F403`/`F405`).
- `noqa` on the Python 2 shims (the bare-except `Queue`/decode fallbacks, the `basestring` fallback) and on one fragile `type(reload) == bool` boolean idiom that is risky to rewrite.

## Safe fixes applied (small, targeted: 9 files, +37/-40)
- `not x is` / `not x in` rewritten to `x is not` / `x not in`.
- Removed genuinely unused imports (`time`, `types`, unused `ManagerError`/`generic_transforms` re-imports).
- Two invalid escape sequences (`\d`, `\*`) turned into raw strings (real correctness fixes).
- Split one `import a, b, c`, renamed an ambiguous `l` loop variable, and dropped an unused `with ... as` binding.

No `ruff format` and no formatting changes. The removed imports were accidental, non-public module-level names (`time`, `types`, and unused re-imports of `ManagerError`/`generic_transforms`); the documented import paths and the package's public API are unaffected, and no internal code referenced them. No other behavior change.

## Pre-commit and CI
- `.pre-commit-config.yaml`: `ruff-check --fix` plus non-mutating hygiene hooks (YAML and TOML validity, merge-conflict and large-file guards). No whitespace-mutating hooks, consistent with deferring formatting.
- A `Lint` job in CI runs `ruff check` (ruff pinned to match the pre-commit hook).
- README Contributing refreshed for the test suite, CI, and lint setup, which the old text predated.

## Verification
- `ruff check .` passes.
- `pre-commit run --all-files` passes.
- Suite still green: 35 passed.

## Follow-up
- The `ruff format` pass, paired with Python 2 shim removal (which will let the `basestring`/`Queue` ignores drop).
- After merge, add the `Lint` check to branch protection's required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

