### PR TITLE
Remove Python 2 compatibility shims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,19 +77,14 @@ This fork's main feature is FastAGI throughput. `_ThreadedTCPServer` (`fastagi.p
 - **Add an AGI command**: subclass `_Action` in `agi/core.py`. Override `process_response()` to parse the reply.
 - The `app_*` and `dahdi` modules are this same pattern applied to Asterisk add-on modules. Follow their structure for new modules.
 
-## Python version and legacy shims
+## Python version and Python 3 boundaries
 
-The project targets Python 3.9+. The source still carries Python 2 compatibility shims left over from the 2-to-3 migration. These are slated for removal, so don't add new ones:
+The project targets Python 3.9+ and the source is Python 3 only. The earlier Python 2 compatibility shims were removed (#47), so don't reintroduce patterns like `basestring` checks or `import Queue` fallbacks.
 
-- Import fallbacks like `try: import queue except: import Queue as queue` (`ami.py:45`).
-- `basestring` detection in `generic_transforms.py`.
+Two bytes/string details at the I/O boundary are not Python 2 baggage and must stay:
 
-Two related details are not Python 2 baggage and must stay:
-
-- Explicit bytes/string conversion at the socket boundary via `string_to_bytes` and `bytes_to_string`.
-- The AMI socket opens in binary mode (`makefile(mode="rb")`, `ami.py:1195`) on purpose. Text mode silently drops carriage returns and breaks Asterisk's CRLF message framing. Do not change this.
-
-Known gap: `pystrix/agi/fastagi.py` still uses the removed `cgi.urlparse.parse_qs`, which breaks FastAGI query-string parsing on Python 3 and blocks Python 3.13. Tracked in #36.
+- Explicit bytes/string conversion via `string_to_bytes` and `bytes_to_string`.
+- The AMI socket opens in binary mode (`makefile(mode="rb")` in `ami.py`) on purpose. Text mode silently drops carriage returns and breaks Asterisk's CRLF message framing. Do not change this.
 
 ## Working in this repo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The Python 2 compatibility shims: the `queue` and `socketserver` import fallbacks, the `basestring` branch in `generic_transforms`, and the explicit `(object)` base classes. The codebase is now Python 3 only.
 
 ### Fixed
-- Applied safe lint fixes surfaced by ruff: `not x is`/`not x in` rewritten to `x is not`/`x not in`, removed unused imports, and turned two invalid escape sequences (`\d`, `\*`) into raw strings. The Python 2 shims and intentional re-exports are marked with targeted ignores.
+- Applied safe lint fixes surfaced by ruff: `not x is`/`not x in` rewritten to `x is not`/`x not in`, removed unused imports, and turned two invalid escape sequences (`\d`, `\*`) into raw strings. Intentional re-exports are marked with targeted ignores.
 - `_Request.build_request` now honors its documented ActionID precedence: an explicit argument wins, then a value already set on the request, then a generated one. Previously a pre-set ActionID was dropped when no argument was passed, and it overrode an explicit argument. The resolved ActionID is also coerced to a string so a pre-set non-string value matches Asterisk's responses (#43).
 - Replaced the removed `cgi.urlparse.parse_qs` in `pystrix/agi/fastagi.py` with `urllib.parse.parse_qs`. This fixes FastAGI query-string parsing on all Python 3 and restores Python 3.13 support (#36).
 - `build-release.py` no longer fails on the missing `pystrix.spec`. The RPM packaging path was removed, and the release tarball now ships `README.md` and `CHANGELOG.md` so a build from the sdist can read the long description.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Removed the `AUTHORS` file. Provenance now lives in the README, and the contributor list comes from git history and the GitHub contributors page.
 - Modernized `doc/conf.py` (`exclude_patterns`, Read the Docs theme with a fallback, raw-string regex).
 
+### Removed
+- The Python 2 compatibility shims: the `queue` and `socketserver` import fallbacks, the `basestring` branch in `generic_transforms`, and the explicit `(object)` base classes. The codebase is now Python 3 only.
+
 ### Fixed
 - Applied safe lint fixes surfaced by ruff: `not x is`/`not x in` rewritten to `x is not`/`x not in`, removed unused imports, and turned two invalid escape sequences (`\d`, `\*`) into raw strings. The Python 2 shims and intentional re-exports are marked with targeted ignores.
 - `_Request.build_request` now honors its documented ActionID precedence: an explicit argument wins, then a value already set on the request, then a generated one. Previously a pre-set ActionID was dropped when no argument was passed, and it overrode an explicit argument. The resolved ActionID is also coerced to a string so a pre-set non-string value matches Asterisk's responses (#43).

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ A few things to know before you send a change:
 
 - **Run the tests** with `pytest`. CI runs them across Python 3.9 through 3.13 on every pull request. There is no live-Asterisk integration test, so socket-level behavior is still worth checking against a real server (AMI on port 5038, FastAGI on port 4573).
 - **Lint with ruff.** `ruff check .` must pass, and CI enforces it. Install the hooks to lint on each commit: `pip install pre-commit && pre-commit install`. Formatting is not enforced yet.
-- **Target Python 3.9+.** The codebase still carries Python 2 compatibility shims (the `Queue` import fallback, `basestring` checks). These are being removed during modernization, so don't add new ones.
+- **Target Python 3.9+.** The codebase is Python 3 only; the old Python 2 compatibility shims have been removed, so don't reintroduce them.
 - **Build the docs** when you touch them: `pip install -r doc/requirements.txt`, then `cd doc && make html`.
 - **Version bumps** go in `pystrix/__init__.py`. `setup.py` reads `VERSION` from there.
 - **Keep docstrings complete** and written in reStructuredText. The reference docs are generated from them.

--- a/pystrix/agi/agi_core.py
+++ b/pystrix/agi/agi_core.py
@@ -62,7 +62,7 @@ def quote(value):
 
 #Classes
 ###############################################################################
-class _AGI(object):
+class _AGI:
     """
     This class encapsulates communication between Asterisk an a python script.
     It handles encoding commands to Asterisk and parsing responses from
@@ -256,7 +256,7 @@ class _AGI(object):
         """
         return
 
-class _Action(object):
+class _Action:
     """
     Provides the basis for assembling and issuing an action via AGI.
     """

--- a/pystrix/agi/fastagi.py
+++ b/pystrix/agi/fastagi.py
@@ -43,10 +43,7 @@ from urllib.parse import parse_qs
 from pystrix.agi.agi_core import *
 from pystrix.agi.agi_core import _AGI
 
-try:
-    import socketserver
-except ModuleNotFoundError:
-    import SocketServer as socketserver
+import socketserver
 
 
 class _ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):

--- a/pystrix/ami/ami.py
+++ b/pystrix/ami/ami.py
@@ -42,10 +42,7 @@ import time
 import traceback
 import warnings
 
-try:
-    import queue
-except:  # noqa: E722
-    import Queue as queue
+import queue
 
 from pystrix.ami import generic_transforms
 
@@ -91,7 +88,7 @@ def _format_socket_error(exception):
     except Exception:
         return str(exception)
         
-class Manager(object):
+class Manager:
     _alive = True #False when this manager object is ready to be disposed of
     _action_id = None #The ActionID last sent to Asterisk
     _action_id_random_token = None #A randomly generated token, used to help avoid conflicts when multiple AMI connections are in use
@@ -647,7 +644,7 @@ class Manager(object):
                 del self._outstanding_requests[action_id]
             return served
 
-class _MessageTemplate(object):
+class _MessageTemplate:
     """
     An abstract base-class for all message-types, including aggregates.
     """
@@ -1047,7 +1044,7 @@ class _MessageReader(threading.Thread):
                 else: #It's an orphaned response
                     self.response_queue.put(message)
                     
-class _SynchronisedSocket(object):
+class _SynchronisedSocket:
     """
     Provides a threadsafe conduit for communication with an Asterisk manager interface.
     """

--- a/pystrix/ami/generic_transforms.py
+++ b/pystrix/ami/generic_transforms.py
@@ -28,11 +28,7 @@ Authors:
 
 - Neil Tallim <flan@uguu.ca>
 """
-import sys
-
-
-# identify string type in a python 2 and 3 compatible manner
-string_type = str if sys.version_info[0] >= 3 else basestring  # noqa: F821
+string_type = str
 
 
 def to_bool(dictionary, keys, truth_value=None, truth_function=(lambda x:bool(x)), preprocess=(lambda x:x)):


### PR DESCRIPTION
Closes #47

## Summary

Removes the Python 2 compatibility remnants. The project already targets Python 3.9+ (`python_requires`, CI matrix), so these were dead on Python 3. Removing them also lets the `noqa` ignores added in #45 drop.

## Changes
- `pystrix/ami/ami.py`: `import queue` directly, dropping the `Queue as queue` fallback and its `# noqa: E722`.
- `pystrix/agi/fastagi.py`: `import socketserver` directly, dropping the `SocketServer` fallback.
- `pystrix/ami/generic_transforms.py`: `string_type = str`, dropping the `basestring` branch and its `# noqa: F821`. Removed the now-unused `import sys`.
- Dropped the explicit `(object)` base from five class definitions (`Manager`, `_MessageTemplate`, `_SynchronisedSocket`, `_AGI`, `_Action`).

## Deliberately left
- The `decode()` bare-except in `pystrix/agi/agi_core.py` is not a Python 2 shim — it handles socket bytes versus stdin strings on Python 3 — so it and its `# noqa: E722` stay.

## Verification
- No `basestring`, `Queue`, `SocketServer`, or `sys.version_info` remnants remain.
- `ruff check .` passes; `RUF100` confirms no unused `noqa` (the two remaining ignores still suppress live violations).
- Package imports cleanly; 35 tests pass.

## Follow-up
- The `ruff format` pass.
- `pyproject.toml` + SPDX migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
