### PR TITLE
Narrow the decode() bare-except in _AGI._read_line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The Python 2 compatibility shims: the `queue` and `socketserver` import fallbacks, the `basestring` branch in `generic_transforms`, and the explicit `(object)` base classes. The codebase is now Python 3 only.
 
 ### Fixed
+- Narrowed the bare `except` around `line.decode()` in `_AGI._read_line` to an `isinstance(line, bytes)` check. A real `UnicodeDecodeError` on malformed socket bytes now surfaces instead of being swallowed and leaving raw bytes in the line (#50).
 - Applied safe lint fixes surfaced by ruff: `not x is`/`not x in` rewritten to `x is not`/`x not in`, removed unused imports, and turned two invalid escape sequences (`\d`, `\*`) into raw strings. Intentional re-exports are marked with targeted ignores.
 - `_Request.build_request` now honors its documented ActionID precedence: an explicit argument wins, then a value already set on the request, then a generated one. Previously a pre-set ActionID was dropped when no argument was passed, and it overrode an explicit argument. The resolved ActionID is also coerced to a string so a pre-set non-string value matches Asterisk's responses (#43).
 - Replaced the removed `cgi.urlparse.parse_qs` in `pystrix/agi/fastagi.py` with `urllib.parse.parse_qs`. This fixes FastAGI query-string parsing on all Python 3 and restores Python 3.13 support (#36).

--- a/pystrix/agi/agi_core.py
+++ b/pystrix/agi/agi_core.py
@@ -205,10 +205,8 @@ class _AGI:
         """
         try:
             line = self._rfile.readline()
-            try:
-                line = line.decode()  # decode line if it comes in bytes, example if it comes from a socket
-            except:  # noqa: E722
-                pass  # line it's a string, so nothing to change - it's string if it's using stdin as _rfile for example
+            if isinstance(line, bytes):  # bytes from a FastAGI socket; already str from stdin (AGI)
+                line = line.decode()
             # Check to see if we received a HANGUP because AGISIGHUP was not set explicitly or is no
             # and then handle the HANGUP which is being returned because the AGI script can still interact with
             # Asterisk after the call was hungup in DeadAGI mode (which Asterisk converts the channel to automatically)

--- a/tests/test_agi_core.py
+++ b/tests/test_agi_core.py
@@ -115,3 +115,41 @@ def test_action_command_formatting():
 def test_quote_wraps_in_double_quotes():
     assert quote('demo') == '"demo"'
     assert quote(5) == '"5"'
+
+
+class _StrReader:
+    """A reader that yields str lines, as plain AGI's stdin does."""
+
+    def __init__(self, *lines):
+        self._lines = list(lines)
+        self._index = 0
+
+    def readline(self):
+        if self._index >= len(self._lines):
+            return ''
+        line = self._lines[self._index]
+        self._index += 1
+        return line
+
+
+def _agi_with_reader(reader):
+    agi = _AGI.__new__(_AGI)
+    agi._environment = {}
+    agi._rfile = reader
+    return agi
+
+
+def test_str_input_is_read_without_decoding():
+    # Plain AGI reads str from stdin; _read_line must not choke trying to decode it.
+    response = _agi_with_reader(_StrReader('200 result=1\n'))._get_result()
+    assert response.items['result'].value == '1'
+
+
+def test_malformed_bytes_surface_a_decode_error():
+    # A real decode failure on socket bytes propagates instead of being swallowed.
+    class _BadBytesReader:
+        def readline(self):
+            return b'\xff\xfe not utf-8\n'
+
+    with pytest.raises(UnicodeDecodeError):
+        _agi_with_reader(_BadBytesReader())._get_result()


### PR DESCRIPTION
Closes #50

## Summary

The bare `except` around `line.decode()` in `_AGI._read_line` was too broad. It correctly handled two Python 3 cases (stdin gives `str`, a FastAGI socket gives `bytes`), but it also swallowed a real `UnicodeDecodeError` on malformed socket bytes, leaving `line` as `bytes` flowing into string-only logic downstream.

## Fix

```python
line = self._rfile.readline()
if isinstance(line, bytes):  # bytes from a FastAGI socket; already str from stdin (AGI)
    line = line.decode()
```

- str from stdin passes through untouched.
- bytes from a socket decode as before.
- A genuine `UnicodeDecodeError` now surfaces instead of being masked.

This also removes the last bare-except (and its `# noqa: E722`) from the file. The only remaining noqa in the package is the `E721` on the legacy `type(reload) == bool` idiom.

## Tests

Two regression tests added: the str-input path (stdin) and the malformed-bytes path (asserts `UnicodeDecodeError` propagates). Suite: 37 passed (was 35).

## Verification
- `ruff check` passes; `RUF100` confirms no unused noqa.
- 37 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
