### PR TITLE
Apply ruff format and enable import sorting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Revisions listed here are skipped by `git blame` (git 2.23+) and GitHub.
+# Configure locally with: git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Reformat with ruff format and sort imports (#52)
+a494c88d84f14d26c9ce35dabafe15eb7124cb3e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: pip install ruff==0.15.19
       - name: Run ruff
         run: ruff check .
+      - name: Check formatting
+        run: ruff format --check .
 
   test:
     name: Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,12 @@
 # Pre-commit hooks for pystrix. Run `pre-commit install` once to enable, then
 # the hooks run on each commit. See https://pre-commit.com.
-#
-# Formatting hooks are intentionally omitted for now (see issue #45); ruff is
-# used for linting only until a dedicated formatting pass.
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.19
     hooks:
       - id: ruff-check
         args: [--fix]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - A `pytest` unit-test suite covering AMI message parsing and request building, AGI response parsing, and action and helper formatting, with `pytest` and `pytest-cov` in a `test` extra in `setup.py` (`pip install -e '.[test]'`).
 - Coverage measurement through `pytest-cov`, reported in the CI logs. No coverage data leaves CI.
 - A CI status badge in the README.
-- A curated `ruff` lint configuration (`ruff.toml`), a `.pre-commit-config.yaml`, and a CI lint job. Linting only for now; formatting is deferred.
+- A curated `ruff` lint configuration (`ruff.toml`), a `.pre-commit-config.yaml`, and a CI lint job.
 - This changelog.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Narrowed the "any platform" claim. The FastAGI server runs on Linux and macOS only, because it reads `SOMAXCONN` with `sysctl`.
 - Removed the `AUTHORS` file. Provenance now lives in the README, and the contributor list comes from git history and the GitHub contributors page.
 - Modernized `doc/conf.py` (`exclude_patterns`, Read the Docs theme with a fallback, raw-string regex).
+- Formatted the whole codebase with `ruff format` (line length 88) and enabled import sorting (ruff's `I` rule). Both are now enforced in pre-commit and CI. A `.git-blame-ignore-revs` file lets `git blame` skip the reformat commit.
 
 ### Removed
 - The Python 2 compatibility shims: the `queue` and `socketserver` import fallbacks, the `basestring` branch in `generic_transforms`, and the explicit `(object)` base classes. The codebase is now Python 3 only.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The editable install (`-e`) means your local edits take effect without reinstall
 A few things to know before you send a change:
 
 - **Run the tests** with `pytest`. CI runs them across Python 3.9 through 3.13 on every pull request. There is no live-Asterisk integration test, so socket-level behavior is still worth checking against a real server (AMI on port 5038, FastAGI on port 4573).
-- **Lint with ruff.** `ruff check .` must pass, and CI enforces it. Install the hooks to lint on each commit: `pip install pre-commit && pre-commit install`. Formatting is not enforced yet.
+- **Lint and format with ruff.** `ruff check .` and `ruff format --check .` must pass, and CI enforces both. Install the hooks to run them on each commit: `pip install pre-commit && pre-commit install`.
 - **Target Python 3.9+.** The codebase is Python 3 only; the old Python 2 compatibility shims have been removed, so don't reintroduce them.
 - **Build the docs** when you touch them: `pip install -r doc/requirements.txt`, then `cd doc && make html`.
 - **Version bumps** go in `pystrix/__init__.py`. `setup.py` reads `VERSION` from there.

--- a/build-release.py
+++ b/build-release.py
@@ -2,43 +2,51 @@
 """
 Release-building script for pystrix.
 """
+
 import tarfile
 
 from pystrix import VERSION
 
+
 def _filter(tarinfo, acceptable_extensions):
-    if tarinfo.name.startswith('.'): #Ignore hidden files
+    if tarinfo.name.startswith("."):  # Ignore hidden files
         return None
-        
-    if tarinfo.isdir(): #Directories are good
+
+    if tarinfo.isdir():  # Directories are good
         return tarinfo
-        
-    if tarinfo.name.endswith(acceptable_extensions): #It's a file we want
+
+    if tarinfo.name.endswith(acceptable_extensions):  # It's a file we want
         print("\tAdded " + tarinfo.name)
         return tarinfo
-        
-    return None #DO NOT WANT
-    
+
+    return None  # DO NOT WANT
+
+
 def python_filter(tarinfo):
-    return _filter(tarinfo, ('.py',))
+    return _filter(tarinfo, (".py",))
+
 
 def doc_filter(tarinfo):
-    return _filter(tarinfo, ('.py','.rst','Makefile'))
-    
-if __name__ == '__main__':
+    return _filter(tarinfo, (".py", ".rst", "Makefile"))
+
+
+if __name__ == "__main__":
     base_name = "pystrix-" + VERSION
     archive_name = base_name + ".tar.bz2"
     print("Assembling " + archive_name)
     f = tarfile.open(name=archive_name, mode="w:bz2")
-    f.add('COPYING', arcname="%s/COPYING" % base_name)
-    f.add('COPYING.LESSER', arcname="%s/COPYING.LESSER" % base_name)
+    f.add("COPYING", arcname="%s/COPYING" % base_name)
+    f.add("COPYING.LESSER", arcname="%s/COPYING.LESSER" % base_name)
     print("\tAdded license files")
-    f.add('README.md', arcname="%s/README.md" % base_name)
-    f.add('CHANGELOG.md', arcname="%s/CHANGELOG.md" % base_name)
+    f.add("README.md", arcname="%s/README.md" % base_name)
+    f.add("CHANGELOG.md", arcname="%s/CHANGELOG.md" % base_name)
     print("\tAdded README and changelog")
-    f.add('doc',arcname="%s/doc" % base_name, filter=doc_filter)
-    f.add('build-release.py', arcname="%s/build-release.py" % base_name, filter=python_filter)
-    f.add('setup.py', arcname="%s/setup.py" % base_name, filter=python_filter)
-    f.add('pystrix', arcname="%s/pystrix" % base_name, filter=python_filter)
+    f.add("doc", arcname="%s/doc" % base_name, filter=doc_filter)
+    f.add(
+        "build-release.py",
+        arcname="%s/build-release.py" % base_name,
+        filter=python_filter,
+    )
+    f.add("setup.py", arcname="%s/setup.py" % base_name, filter=python_filter)
+    f.add("pystrix", arcname="%s/pystrix" % base_name, filter=python_filter)
     f.close()
-    

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,40 +1,47 @@
 # -*- coding: utf-8 -*-
-import sys
 import os
 import re
+import sys
 
-sys.path.append(os.path.abspath('..'))
+sys.path.append(os.path.abspath(".."))
 import pystrix as module
-sys.path.remove(os.path.abspath('..'))
-sys.path.append(os.path.abspath('../pystrix'))
 
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage']
-templates_path = ['_templates']
-source_suffix = '.rst'
-master_doc = 'index'
+sys.path.remove(os.path.abspath(".."))
+sys.path.append(os.path.abspath("../pystrix"))
 
-project = u'pystrix'
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.todo", "sphinx.ext.coverage"]
+templates_path = ["_templates"]
+source_suffix = ".rst"
+master_doc = "index"
+
+project = "pystrix"
 copyright = module.COPYRIGHT
-version = re.match(r'^(\d+\.\d+)', module.VERSION).group(1)
+version = re.match(r"^(\d+\.\d+)", module.VERSION).group(1)
 release = module.VERSION
 
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # Prefer the Read the Docs theme when it is installed; fall back to the
 # bundled 'alabaster' theme so local builds work without extra packages.
 try:
     import sphinx_rtd_theme  # noqa: F401
-    html_theme = 'sphinx_rtd_theme'
+
+    html_theme = "sphinx_rtd_theme"
 except ImportError:
-    html_theme = 'alabaster'
-html_static_path = ['_static']
+    html_theme = "alabaster"
+html_static_path = ["_static"]
 html_show_sourcelink = False
 
-htmlhelp_basename = 'pystrixdoc'
+htmlhelp_basename = "pystrixdoc"
 
 latex_documents = [
-  ('index', 'pystrix.tex', u'pystrix Documentation',
-   re.search(', (.*?) <', module.COPYRIGHT).group(1), 'manual'),
+    (
+        "index",
+        "pystrix.tex",
+        "pystrix Documentation",
+        re.search(", (.*?) <", module.COPYRIGHT).group(1),
+        "manual",
+    ),
 ]

--- a/pystrix/__init__.py
+++ b/pystrix/__init__.py
@@ -14,7 +14,7 @@ Usage
 
 Importing this package, or the 'agi' or 'ami' sub-packages is recommended over
 importing individual modules.
- 
+
 Legal
 -----
 
@@ -32,15 +32,16 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU General Public License and
 GNU Lesser General Public License along with this program. If not, see
 <http://www.gnu.org/licenses/>.
- 
+
 (C) Ivrnet, inc., 2011
 
 Authors:
 
 - Neil Tallim <n.tallim@ivrnet.com>
 """
+
 import pystrix.agi
 import pystrix.ami
 
-VERSION = '1.2.0'
-COPYRIGHT = '2013, Neil Tallim <flan@uguu.ca>'
+VERSION = "1.2.0"
+COPYRIGHT = "2013, Neil Tallim <flan@uguu.ca>"

--- a/pystrix/agi/__init__.py
+++ b/pystrix/agi/__init__.py
@@ -4,7 +4,7 @@ pystrix.agi
 
 Provides a library suitable for interacting with an Asterisk server using the
 Asterisk Gateway Interface (AGI) protocol.
- 
+
 Usage
 -----
 
@@ -27,27 +27,33 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU General Public License and
 GNU Lesser General Public License along with this program. If not, see
 <http://www.gnu.org/licenses/>.
- 
+
 (C) Ivrnet, inc., 2011
 
 Authors:
 
 - Neil Tallim <n.tallim@ivrnet.com>
 """
-from pystrix.agi.agi_core import (
- AGIException, AGIError, AGINoResultError, AGIUnknownError, AGIAppError,
- AGIHangup, AGISIGPIPEHangup, AGIResultHangup,
- AGIDeadChannelError, AGIUsageError, AGIInvalidCommandError,
-)
-
-from pystrix.agi.agi import (
- AGI,
- AGISIGHUPHangup,
-)
-
-from pystrix.agi.fastagi import (
- FastAGIServer, FastAGI,
-)
 
 from pystrix.agi import core
-
+from pystrix.agi.agi import (
+    AGI,
+    AGISIGHUPHangup,
+)
+from pystrix.agi.agi_core import (
+    AGIAppError,
+    AGIDeadChannelError,
+    AGIError,
+    AGIException,
+    AGIHangup,
+    AGIInvalidCommandError,
+    AGINoResultError,
+    AGIResultHangup,
+    AGISIGPIPEHangup,
+    AGIUnknownError,
+    AGIUsageError,
+)
+from pystrix.agi.fastagi import (
+    FastAGI,
+    FastAGIServer,
+)

--- a/pystrix/agi/agi.py
+++ b/pystrix/agi/agi.py
@@ -4,7 +4,7 @@ pystrix.agi.agi
 
 Provides a class that exposes methods for communicating with Asterisk from an
 AGI (script) context.
-  
+
 Legal
 -----
 
@@ -22,26 +22,29 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU General Public License and
 GNU Lesser General Public License along with this program. If not, see
 <http://www.gnu.org/licenses/>.
- 
+
 (C) Ivrnet, inc., 2011
 
 Authors:
 
 - Neil Tallim <n.tallim@ivrnet.com>
 """
+
 import signal
 import sys
 
 from pystrix.agi.agi_core import *
 from pystrix.agi.agi_core import _AGI
 
+
 class AGI(_AGI):
     """
     An interface to Asterisk, exposing request-response functions for
     synchronous management of the call associated with this channel.
     """
-    _got_sighup = False #True when a hangup signal has been received.
-    
+
+    _got_sighup = False  # True when a hangup signal has been received.
+
     def __init__(self, debug=False):
         """
         Binds the SIGHUP signal and associates I/O with stdin/stdout.
@@ -51,32 +54,32 @@ class AGI(_AGI):
         signal.signal(signal.SIGHUP, self._handle_sighup)
         self._rfile = sys.stdin
         self._wfile = sys.stdout
-        
+
         _AGI.__init__(self, debug)
-        
+
     def _handle_sighup(self, signum, frame):
         """
         Sets the has-hungup flag to trigger an exception when the next command
         is received.
         """
         self._got_sighup = True
-        
+
     def _test_hangup(self):
         """
         If SIGHUP has been received, or another hangup flag has been set, an
         exception is raised; if not, this function is a no-op.
-        
+
         Raises `AGISIGHUPHangup` if SIGHUP has been recieved, or any other exceptions
         normally raised by `_AGI`'s `_test_hangup()`.
         """
         if self._got_sighup:
             raise AGISIGHUPHangup("Received SIGHUP from Asterisk")
-            
+
         _AGI._test_hangup(self)
-        
+
+
 class AGISIGHUPHangup(AGIHangup):
     """
     Indicates that the script's process received the SIGHUP signal, implying
     Asterisk has hung up the call. Specific to script-based instances.
     """
-    

--- a/pystrix/agi/agi_core.py
+++ b/pystrix/agi/agi_core.py
@@ -34,21 +34,23 @@ Authors:
 
 - Neil Tallim <n.tallim@ivrnet.com>
 """
+
 import collections
 import re
-
 import sys
 
-_Response = collections.namedtuple('Response', ('items', 'code', 'raw'))
-_ValueData = collections.namedtuple('ValueData', ('value', 'data'))
+_Response = collections.namedtuple("Response", ("items", "code", "raw"))
+_ValueData = collections.namedtuple("ValueData", ("value", "data"))
 
-_RE_CODE = re.compile(r'(^\d+)\s*(.+)') #Matches Asterisk's response-code lines
-_RE_KV = re.compile(r'(?P<key>\w+)=(?P<value>[^\s]+)?(?:\s+\((?P<data>.*)\))?') #Matches Asterisk's key-value response-pairs
+_RE_CODE = re.compile(r"(^\d+)\s*(.+)")  # Matches Asterisk's response-code lines
+_RE_KV = re.compile(
+    r"(?P<key>\w+)=(?P<value>[^\s]+)?(?:\s+\((?P<data>.*)\))?"
+)  # Matches Asterisk's key-value response-pairs
 
-_RESULT_KEY = 'result'
+_RESULT_KEY = "result"
 
 
-#Functions
+# Functions
 ###############################################################################
 def quote(value):
     """
@@ -56,23 +58,26 @@ def quote(value):
     necessary.
     """
     return '"%(value)s"' % {
-     'value': str(value),
+        "value": str(value),
     }
 
 
-#Classes
+# Classes
 ###############################################################################
 class _AGI:
     """
     This class encapsulates communication between Asterisk an a python script.
     It handles encoding commands to Asterisk and parsing responses from
-    Asterisk. 
+    Asterisk.
     """
-    _environment = None #The environment variables received from Asterisk for this channel
-    _debug = False #If True, development information is printed to console
-    _rfile = None #The input file-like-object
-    _wfile = None #The output file-like-object
-    
+
+    _environment = (
+        None  # The environment variables received from Asterisk for this channel
+    )
+    _debug = False  # If True, development information is printed to console
+    _rfile = None  # The input file-like-object
+    _wfile = None  # The output file-like-object
+
     def __init__(self, debug=False):
         """
         Sets up variables required to process an AGI session.
@@ -80,7 +85,7 @@ class _AGI:
         `debug` should only be turned on for library development.
         """
         self._debug = debug
-        
+
         self._environment = {}
         self._parse_agi_environment()
 
@@ -95,14 +100,14 @@ class _AGI:
         still connected. An instance of `AGIHangup` is raised if it is not.
         """
         self._test_hangup()
-        
+
         self._send_command(action.command)
         return action.process_response(self._get_result(action.check_hangup))
 
     def get_environment(self):
         """
         Returns Asterisk's initial environment variables as a dictionary.
-        
+
         Note that this function returns a copy of the values, so repeated calls
         are less favourable than storing the returned value locally and
         dissecting it there.
@@ -127,35 +132,41 @@ class _AGI:
         `AGIInvalidCommandError` is raised if the given command is unrecognised, either because the
         requested function isn't implemented in the current version of Asterisk or because the
         `execute()` function was invoked incorrectly.
-        
+
         `AGIUsageError` is emitted if the arguments provided for a command are invalid.
-        
+
         `AGIDeadChannelError` occurs if a command is attempted on a dead channel.
 
         `AGIUnknownError` covers any unrecognised Asterisk response code.
         """
         code = 0
         response = {}
-        
+
         line = self._read_line()
         m = _RE_CODE.search(line)
         if m:
             code = int(m.group(1))
-            
+
         if code == 200:
-            raw = m.group(2) #The entire line, excluding the code
-            for (key, value, data) in _RE_KV.findall(m.group(2)):
-                response[key] = _ValueData(value or '', data)
-                
-            if _RESULT_KEY not in response: #Must always be present.
-                raise AGINoResultError("Asterisk did not provide a '%(result-key)s' key-value pair" % {
-                 'result-key': _RESULT_KEY,
-                }, response)
+            raw = m.group(2)  # The entire line, excluding the code
+            for key, value, data in _RE_KV.findall(m.group(2)):
+                response[key] = _ValueData(value or "", data)
+
+            if _RESULT_KEY not in response:  # Must always be present.
+                raise AGINoResultError(
+                    "Asterisk did not provide a '%(result-key)s' key-value pair"
+                    % {
+                        "result-key": _RESULT_KEY,
+                    },
+                    response,
+                )
 
             result = response.get(_RESULT_KEY)
-            if check_hangup and result.data == 'hangup': #A 'hangup' response usually indicates that the channel was hungup, but it is a legal variable value
+            if (
+                check_hangup and result.data == "hangup"
+            ):  # A 'hangup' response usually indicates that the channel was hungup, but it is a legal variable value
                 raise AGIResultHangup("User hung up during execution", response)
-                
+
             return _Response(response, code, raw)
         elif code == 0:
             # No code was returned by Asterisk.
@@ -171,61 +182,71 @@ class _AGI:
             while True:
                 line = self._read_line()
                 usage.append(line)
-                if '520 End of proper usage.' in line:
+                if "520 End of proper usage." in line:
                     break
-            raise AGIUsageError('\n'.join(usage + ['']))
+            raise AGIUsageError("\n".join(usage + [""]))
         else:
-            raise AGIUnknownError("Unhandled code or undefined response: %(code)i : %(line)s" % {
-             'code': code,
-             'line': repr(line),
-            })
-            
+            raise AGIUnknownError(
+                "Unhandled code or undefined response: %(code)i : %(line)s"
+                % {
+                    "code": code,
+                    "line": repr(line),
+                }
+            )
+
     def _parse_agi_environment(self):
         """
         Reads all of Asterisk's environment variables and stores them in memory.
         """
         while True:
             line = self._read_line()
-            if line == '': #Blank line signals end
+            if line == "":  # Blank line signals end
                 break
-                
-            if ':' in line:
-                (key, data) = line.split(':', 1)
+
+            if ":" in line:
+                (key, data) = line.split(":", 1)
                 key = key.strip()
                 data = data.strip()
                 if key:
                     self._environment[key] = data
-                    
+
     def _read_line(self, should_strip=True):
         """
         Reads and returns a line from the Asterisk pipe, blocking until a complete line is
         assembled.
-        
+
         If the pipe is closed before this happens, `AGISIGPIPEHangup` is raised.
         """
         try:
             line = self._rfile.readline()
-            if isinstance(line, bytes):  # bytes from a FastAGI socket; already str from stdin (AGI)
+            if isinstance(
+                line, bytes
+            ):  # bytes from a FastAGI socket; already str from stdin (AGI)
                 line = line.decode()
             # Check to see if we received a HANGUP because AGISIGHUP was not set explicitly or is no
             # and then handle the HANGUP which is being returned because the AGI script can still interact with
             # Asterisk after the call was hungup in DeadAGI mode (which Asterisk converts the channel to automatically)
             # All commands won't work in DeadAGI but that is not our concern here because if such a command is issued
             # which indeed requires channel interaction, Asterisk will respond with a 511 code.
-            if 'no' == self._environment.get('AGISIGHUP', 'no') and 'HANGUP\n' == line:
-                line = self._read_line(should_strip=False) # read from pipe again to get response for the given command
-            if not line: #EOF encountered
+            if "no" == self._environment.get("AGISIGHUP", "no") and "HANGUP\n" == line:
+                line = self._read_line(
+                    should_strip=False
+                )  # read from pipe again to get response for the given command
+            if not line:  # EOF encountered
                 raise AGISIGPIPEHangup("Process input pipe closed")
-            elif not line.endswith('\n'): #Fragment encountered
-                #Recursively append to the current fragment until the line is
-                #complete or the socket dies.
+            elif not line.endswith("\n"):  # Fragment encountered
+                # Recursively append to the current fragment until the line is
+                # complete or the socket dies.
                 line += self._read_line()
             return line.strip() if should_strip else line
         except IOError as e:
-            raise AGISIGPIPEHangup("Process input pipe broken: %(error)s" % {
-             'error': str(e),
-            })
-            
+            raise AGISIGPIPEHangup(
+                "Process input pipe broken: %(error)s"
+                % {
+                    "error": str(e),
+                }
+            )
+
     def _send_command(self, command, *args):
         """
         Formats a `command` and sends it to Asterisk.
@@ -236,43 +257,55 @@ class _AGI:
         If the connection to Asterisk is broken, `AGISIGPIPEHangup` is raised.
         """
         try:
-            if self._wfile is not sys.stdout:  # stdout handles str instead of bytes, so we don't encode
+            if (
+                self._wfile is not sys.stdout
+            ):  # stdout handles str instead of bytes, so we don't encode
                 command = command.encode()
             self._wfile.write(command)
             self._wfile.flush()
         except Exception as e:
-            raise AGISIGPIPEHangup("Socket link broken: %(error)s" % {
-             'error': str(e),
-            })
-            
+            raise AGISIGPIPEHangup(
+                "Socket link broken: %(error)s"
+                % {
+                    "error": str(e),
+                }
+            )
+
     def _test_hangup(self):
         """
         Tests to see if the channel has been hung up.
-        
+
         At present, this is a no-op because no generic hang-up conditions are
         known, but subclasses may have specific scenarios to test for.
         """
         return
 
+
 class _Action:
     """
     Provides the basis for assembling and issuing an action via AGI.
     """
-    _command = None #The command that drives this action
-    _arguments = None #A tuple of arguments to qualify the command
-    check_hangup = True #True if the output of this action is sure to be hangup-detection-safe
-    
+
+    _command = None  # The command that drives this action
+    _arguments = None  # A tuple of arguments to qualify the command
+    check_hangup = (
+        True  # True if the output of this action is sure to be hangup-detection-safe
+    )
+
     def __init__(self, command, *arguments):
         self._command = command
         self._arguments = arguments
 
     @property
     def command(self):
-        command = ' '.join([self._command.strip()] + [str(arg) for arg in self._arguments if arg is not None]).strip()
-        if not command.endswith('\n'):
-            command += '\n'
+        command = " ".join(
+            [self._command.strip()]
+            + [str(arg) for arg in self._arguments if arg is not None]
+        ).strip()
+        if not command.endswith("\n"):
+            command += "\n"
         return command
-        
+
     def process_response(self, response):
         """
         Just returns the `response` from Asterisk verbatim. May be overridden to allow for
@@ -281,68 +314,78 @@ class _Action:
         return response
 
 
-#Exceptions
+# Exceptions
 ###############################################################################
 class AGIException(Exception):
     """
     The base exception from which all exceptions native to this module inherit.
     """
-    items = None #Any items received from Asterisk, as a dictionary.
+
+    items = None  # Any items received from Asterisk, as a dictionary.
 
     def __init__(self, message, items=None):
         Exception.__init__(self, message)
         self.items = items if items else {}
-        
+
+
 class AGIError(AGIException):
     """
     The base error from which all errors native to this module inherit.
     """
-    
+
+
 class AGINoResultError(AGIException):
     """
     Indicates that Asterisk did not return a 'result' parameter in a 200 response.
     """
-    
+
+
 class AGIUnknownError(AGIError):
     """
     An error raised when an unknown response is received from Asterisk.
     """
-    
+
+
 class AGIAppError(AGIError):
     """
     An error raised when an attempt to make use of an Asterisk application
     fails.
     """
-    
+
+
 class AGIDeadChannelError(AGIError):
     """
     Indicates that a command was issued on a channel that can no longer process
     it.
     """
-    
+
+
 class AGIInvalidCommandError(AGIError):
     """
     Indicates that a request made to Asterisk was not understood.
     """
-    
+
+
 class AGIUsageError(AGIError):
     """
     Indicates that a request made to Asterisk was sent with invalid syntax.
     """
-    
+
+
 class AGIHangup(AGIException):
     """
     The base exception used to indicate that the call has been completed or
     abandoned.
     """
-    
+
+
 class AGISIGPIPEHangup(AGIHangup):
     """
     Indicates that the communications pipe to Asterisk has been severed.
     """
-    
+
+
 class AGIResultHangup(AGIHangup):
     """
     Indicates that Asterisk received a clean hangup event.
     """
-    

--- a/pystrix/agi/core.py
+++ b/pystrix/agi/core.py
@@ -6,7 +6,7 @@ All standard AGI actions as instantiable classes, suitable for passing to the
 `execute()` function of an AGI interface.
 
 Also includes constants to make programmatic interaction cleaner.
- 
+
 Legal
 -----
 
@@ -24,20 +24,21 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU General Public License and
 GNU Lesser General Public License along with this program. If not, see
 <http://www.gnu.org/licenses/>.
- 
+
 (C) Ivrnet, inc., 2011
 
 Authors:
 
 - Neil Tallim <n.tallim@ivrnet.com>
 """
+
 import time
 
 from pystrix.agi.agi_core import (
-    _Action,
-    quote,
     _RESULT_KEY,
     AGIAppError,
+    _Action,
+    quote,
 )
 
 CHANNEL_DOWN_AVAILABLE = 0  # Channel is down and available
@@ -49,14 +50,14 @@ CHANNEL_REMOTE_ALERTING = 5  # The channel is remotely ringing
 CHANNEL_UP = 6  # The channel is connected
 CHANNEL_BUSY = 7  # The channel is in a busy, non-conductive state
 
-FORMAT_SLN = 'sln'
-FORMAT_G723 = 'g723'
-FORMAT_G729 = 'g729'
-FORMAT_GSM = 'gsm'
-FORMAT_ALAW = 'alaw'
-FORMAT_ULAW = 'ulaw'
-FORMAT_VOX = 'vox'
-FORMAT_WAV = 'wav'
+FORMAT_SLN = "sln"
+FORMAT_G723 = "g723"
+FORMAT_G729 = "g729"
+FORMAT_GSM = "gsm"
+FORMAT_ALAW = "alaw"
+FORMAT_ULAW = "ulaw"
+FORMAT_VOX = "vox"
+FORMAT_WAV = "wav"
 
 LOG_DEBUG = 0
 LOG_INFO = 1
@@ -64,9 +65,9 @@ LOG_WARN = 2
 LOG_ERROR = 3
 LOG_CRITICAL = 4
 
-TDD_ON = 'on'
-TDD_OFF = 'off'
-TDD_MATE = 'mate'
+TDD_ON = "on"
+TDD_OFF = "off"
+TDD_MATE = "mate"
 
 
 # Functions
@@ -79,9 +80,13 @@ def _convert_to_char(value, items):
     try:
         return chr(int(value))
     except ValueError:
-        raise AGIAppError("Unable to convert Asterisk result to DTMF character: %(value)r" % {
-            'value': value,
-        }, items)
+        raise AGIAppError(
+            "Unable to convert Asterisk result to DTMF character: %(value)r"
+            % {
+                "value": value,
+            },
+            items,
+        )
 
 
 def _convert_to_int(items):
@@ -89,7 +94,7 @@ def _convert_to_int(items):
     Extracts the offset-value from Asterisk's response, `items`, or returns -1 if the value
     can't be parsed.
     """
-    offset = items.get('endpos')
+    offset = items.get("endpos")
     if offset and offset.data.isdigit():
         return int(offset.data)
     else:
@@ -101,7 +106,7 @@ def _process_digit_list(digits):
     Ensures that digit-lists are processed uniformly.
     """
     if type(digits) in (list, tuple, set, frozenset):
-        digits = ''.join([str(d) for d in digits])
+        digits = "".join([str(d) for d in digits])
     return quote(digits)
 
 
@@ -110,7 +115,7 @@ def _process_digit_list(digits):
 class Answer(_Action):
     """
     Answers the call on the channel.
-    
+
     If the channel has already been answered, this is a no-op.
 
     `AGIAppError` is raised on failure, most commonly because the connection
@@ -118,16 +123,16 @@ class Answer(_Action):
     """
 
     def __init__(self):
-        _Action.__init__(self, 'ANSWER')
+        _Action.__init__(self, "ANSWER")
 
 
 class ChannelStatus(_Action):
     """
     Provides the current state of this channel or, if `channel` is set, that of the named
     channel.
-    
+
     Returns one of the channel-state constants listed below:
-    
+
     - CHANNEL_DOWN_AVAILABLE: Channel is down and available
     - CHANNEL_DOWN_RESERVED: Channel is down and reserved
     - CHANNEL_OFFHOOK: Channel is off-hook
@@ -148,7 +153,7 @@ class ChannelStatus(_Action):
     """
 
     def __init__(self, channel=None):
-        _Action.__init__(self, 'CHANNEL STATUS', (channel and quote(channel)) or None)
+        _Action.__init__(self, "CHANNEL STATUS", (channel and quote(channel)) or None)
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
@@ -156,24 +161,27 @@ class ChannelStatus(_Action):
             return int(result.value)
         except ValueError:
             raise AGIAppError(
-                "'%(result-key)s' key-value pair received from Asterisk contained a non-numeric value: %(value)r" % {
-                    'result-key': _RESULT_KEY,
-                    'value': result.value,
-                }, response.items)
+                "'%(result-key)s' key-value pair received from Asterisk contained a non-numeric value: %(value)r"
+                % {
+                    "result-key": _RESULT_KEY,
+                    "value": result.value,
+                },
+                response.items,
+            )
 
 
 class ControlStreamFile(_Action):
     """
     See also `GetData`, `GetOption`, `StreamFile`.
-    
+
     Plays back the specified file, which is the `filename` of the file to be played, either in
     an Asterisk-searched directory or as an absolute path, without extension. ('myfile.wav'
     would be specified as 'myfile', to allow Asterisk to choose the most efficient encoding,
     based on extension, for the channel)
-    
+
     `escape_digits` may optionally be a list of DTMF digits, specified as a string or a sequence
     of possibly mixed ints and strings. Playback ends immediately when one is received.
-    
+
     `sample_offset` may be used to jump an arbitrary number of milliseconds into the audio data.
 
     If specified, `forward`, `rewind`, and `pause` are DTMF characters that will seek forwards
@@ -182,21 +190,35 @@ class ControlStreamFile(_Action):
 
     If a DTMF key is received, it is returned as a string. If nothing is received or the file
     could not be played back (see Asterisk logs), None is returned.
-    
+
     `AGIAppError` is raised on failure, most commonly because the channel was
     hung-up.
     """
 
-    def __init__(self, filename, escape_digits='', sample_offset=0, forward='', rewind='', pause=''):
+    def __init__(
+        self,
+        filename,
+        escape_digits="",
+        sample_offset=0,
+        forward="",
+        rewind="",
+        pause="",
+    ):
         escape_digits = _process_digit_list(escape_digits)
-        _Action.__init__(self, 'CONTROL STREAM FILE', quote(filename),
-                         quote(escape_digits), quote(sample_offset),
-                         quote(forward), quote(rewind), quote(pause)
-                         )
+        _Action.__init__(
+            self,
+            "CONTROL STREAM FILE",
+            quote(filename),
+            quote(escape_digits),
+            quote(sample_offset),
+            quote(forward),
+            quote(rewind),
+            quote(pause),
+        )
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if not result.value == '0':
+        if not result.value == "0":
             return _convert_to_char(result.value, response.items)
         return None
 
@@ -204,25 +226,29 @@ class ControlStreamFile(_Action):
 class DatabaseDel(_Action):
     """
     Deletes the specified family/key entry from Asterisk's database.
-    
+
     `AGIAppError` is raised on failure.
-    
+
     `AGIDBError` is raised if the key could not be removed, which usually indicates that it
     didn't exist in the first place.
     """
 
     def __init__(self, family, key):
-        _Action.__init__(self, 'DATABASE DEL', quote(family), quote(key))
+        _Action.__init__(self, "DATABASE DEL", quote(family), quote(key))
         self.family = family
         self.key = key
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if result.value == '0':
-            raise AGIDBError("Unable to delete from database: family=%(family)r, key=%(key)r" % {
-                'family': self.family,
-                'key': self.key,
-            }, response.items)
+        if result.value == "0":
+            raise AGIDBError(
+                "Unable to delete from database: family=%(family)r, key=%(key)r"
+                % {
+                    "family": self.family,
+                    "key": self.key,
+                },
+                response.items,
+            )
 
 
 class DatabaseDeltree(_Action):
@@ -230,84 +256,104 @@ class DatabaseDeltree(_Action):
     Deletes the specificed family (and optionally keytree) from Asterisk's database.
 
     `AGIAppError` is raised on failure.
-    
+
     `AGIDBError` is raised if the family (or keytree) could not be removed, which usually
     indicates that it didn't exist in the first place.
     """
 
     def __init__(self, family, keytree=None):
-        _Action.__init__(self,
-                         'DATABASE DELTREE', quote(family), (keytree and quote(keytree) or None)
-                         )
+        _Action.__init__(
+            self,
+            "DATABASE DELTREE",
+            quote(family),
+            (keytree and quote(keytree) or None),
+        )
         self.family = family
         self.keytree = keytree
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if result.value == '0':
-            raise AGIDBError("Unable to delete family from database: family=%(family)r, keytree=%(keytree)r" % {
-                'family': self.family,
-                'keytree': self.keytree or '<unspecified>',
-            }, response.items)
+        if result.value == "0":
+            raise AGIDBError(
+                "Unable to delete family from database: family=%(family)r, keytree=%(keytree)r"
+                % {
+                    "family": self.family,
+                    "keytree": self.keytree or "<unspecified>",
+                },
+                response.items,
+            )
 
 
 class DatabaseGet(_Action):
     """
     Retrieves the value of the specified family/key entry from Asterisk's database.
-    
+
     `AGIAppError` is raised on failure.
-    
+
     `AGIDBError` is raised if the key could not be found or if some other database problem
     occurs.
     """
+
     check_hangup = False
 
     def __init__(self, family, key):
-        _Action.__init__(self, 'DATABASE GET', quote(family), quote(key))
+        _Action.__init__(self, "DATABASE GET", quote(family), quote(key))
         self.family = family
         self.key = key
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if result.value == '0':
-            raise AGIDBError("Key not found in database: family=%(family)r, key=%(key)r" % {
-                'family': self.family,
-                'key': self.key,
-            }, response.items)
-        elif result.value == '1':
+        if result.value == "0":
+            raise AGIDBError(
+                "Key not found in database: family=%(family)r, key=%(key)r"
+                % {
+                    "family": self.family,
+                    "key": self.key,
+                },
+                response.items,
+            )
+        elif result.value == "1":
             return result.data
 
-        raise AGIDBError("Unable to query database: family=%(family)r, key=%(key)r, result=%(result)r" % {
-            'family': self.family,
-            'key': self.key,
-            'result': result.value,
-        }, response.items)
+        raise AGIDBError(
+            "Unable to query database: family=%(family)r, key=%(key)r, result=%(result)r"
+            % {
+                "family": self.family,
+                "key": self.key,
+                "result": result.value,
+            },
+            response.items,
+        )
 
 
 class DatabasePut(_Action):
     """
     Inserts or updates value of the specified family/key entry in Asterisk's database.
-    
+
     `AGIAppError` is raised on failure.
-    
+
     `AGIDBError` is raised if the key could not be inserted or if some other database problem
     occurs.
     """
 
     def __init__(self, family, key, value):
-        _Action.__init__(self, 'DATABASE PUT', quote(family), quote(key), quote(value))
+        _Action.__init__(self, "DATABASE PUT", quote(family), quote(key), quote(value))
         self.family = family
         self.key = key
         self.value = value
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if result.value == '0':
-            raise AGIDBError("Unable to store value in database: family=%(family)r, key=%(key)r, value=%(value)r" % {
-                'family': self.family,
-                'key': self.key,
-                'value': self.value,
-            }, response.items)
+        if result.value == "0":
+            raise AGIDBError(
+                "Unable to store value in database: family=%(family)r, key=%(key)r, value=%(value)r"
+                % {
+                    "family": self.family,
+                    "key": self.key,
+                    "value": self.value,
+                },
+                response.items,
+            )
 
 
 class Exec(_Action):
@@ -320,31 +366,38 @@ class Exec(_Action):
 
     `AGIAppError` is raised if the application could not be executed.
     """
+
     check_hangup = False
 
     def __init__(self, application, options=()):
         self._application = application
-        options = ','.join((str(o or '') for o in options))
-        _Action.__init__(self, 'EXEC', self._application, (options and quote(options)) or '')
+        options = ",".join((str(o or "") for o in options))
+        _Action.__init__(
+            self, "EXEC", self._application, (options and quote(options)) or ""
+        )
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if result.value == '-2':
-            raise AGIAppError("Unable to execute application '%(application)r'" % {
-                'application': self._application,
-            }, response.items)
+        if result.value == "-2":
+            raise AGIAppError(
+                "Unable to execute application '%(application)r'"
+                % {
+                    "application": self._application,
+                },
+                response.items,
+            )
         return response.raw[7:]  # Everything after 'result='
 
 
 class GetData(_Action):
     """
     See also `ControlStreamFile`, `GetOption`, `StreamFile`.
-    
+
     Plays back the specified file, which is the `filename` of the file to be played, either in
     an Asterisk-searched directory or as an absolute path, without extension. ('myfile.wav'
     would be specified as 'myfile', to allow Asterisk to choose the most efficient encoding,
     based on extension, for the channel)
-    
+
     `timeout` is the number of milliseconds to wait between DTMF presses or following the end
     of playback if no keys were pressed to interrupt playback prior to that point. It defaults
     to 2000.
@@ -353,38 +406,39 @@ class GetData(_Action):
 
     The value returned is a tuple consisting of (dtmf_keys:str, timeout:bool). '#' is always
     interpreted as an end-of-event character and will never be present in the output.
-    
+
     `AGIAppError` is raised on failure, most commonly because no keys, aside from '#', were
     entered.
     """
 
     def __init__(self, filename, timeout=2000, max_digits=255):
-        _Action.__init__(self,
-                         'GET DATA', quote(filename), quote(timeout), quote(max_digits)
-                         )
+        _Action.__init__(
+            self, "GET DATA", quote(filename), quote(timeout), quote(max_digits)
+        )
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        return (result.value, result.data == 'timeout')
+        return (result.value, result.data == "timeout")
 
 
 class GetFullVariable(_Action):
     """
     Returns a `variable` associated with this channel, with full expression-processing.
-    
+
     The value of the requested variable is returned as a string. If the variable is
     undefined, `None` is returned.
 
     `AGIAppError` is raised on failure.
     """
+
     check_hangup = False
 
     def __init__(self, variable):
-        _Action.__init__(self, 'GET FULL VARIABLE', quote(variable))
+        _Action.__init__(self, "GET FULL VARIABLE", quote(variable))
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if result.value == '1':
+        if result.value == "1":
             return result.data
         return None
 
@@ -397,31 +451,30 @@ class GetOption(_Action):
     an Asterisk-searched directory or as an absolute path, without extension. ('myfile.wav'
     would be specified as 'myfile', to allow Asterisk to choose the most efficient encoding,
     based on extension, for the channel)
-    
+
     `escape_digits` may optionally be a list of DTMF digits, specified as a string or a sequence
     of possibly mixed ints and strings. Playback ends immediately when one is received.
-    
+
     `timeout` is the number of milliseconds to wait following the end of playback if no keys
     were pressed to interrupt playback prior to that point. It defaults to 2000.
-    
+
     The value returned is a tuple consisting of (dtmf_key:str, offset:int), where the offset is
     the number of milliseconds that elapsed since the start of playback, or None if playback
     completed successfully or the sample could not be opened.
-    
+
     `AGIAppError` is raised on failure, most commonly because the channel was
     hung-up.
     """
 
-    def __init__(self, filename, escape_digits='', timeout=2000):
+    def __init__(self, filename, escape_digits="", timeout=2000):
         escape_digits = _process_digit_list(escape_digits)
-        _Action.__init__(self,
-                         'GET OPTION', quote(filename),
-                         quote(escape_digits), quote(timeout)
-                         )
+        _Action.__init__(
+            self, "GET OPTION", quote(filename), quote(escape_digits), quote(timeout)
+        )
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if not result.value == '0':
+        if not result.value == "0":
             dtmf_character = _convert_to_char(result.value, response.items)
             offset = _convert_to_int(response.items)
             return (dtmf_character, offset)
@@ -431,20 +484,21 @@ class GetOption(_Action):
 class GetVariable(_Action):
     """
     Returns a `variable` associated with this channel.
-    
+
     The value of the requested variable is returned as a string. If the variable is
     undefined, `None` is returned.
 
     `AGIAppError` is raised on failure.
     """
+
     check_hangup = False
 
     def __init__(self, variable):
-        _Action.__init__(self, 'GET VARIABLE', quote(variable))
+        _Action.__init__(self, "GET VARIABLE", quote(variable))
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if result.value == '1':
+        if result.value == "1":
             return result.data
         return None
 
@@ -457,22 +511,22 @@ class Hangup(_Action):
     """
 
     def __init__(self, channel=None):
-        _Action.__init__(self, 'HANGUP', (channel and quote(channel) or None))
+        _Action.__init__(self, "HANGUP", (channel and quote(channel) or None))
 
 
 class Noop(_Action):
     """
     Does nothing.
-    
+
     Good for testing the connection to the Asterisk server, like a ping, but
     not useful for much else. If you wish to log information through
     Asterisk, use the `verbose` method instead.
-    
+
     `AGIAppError` is raised on failure.
     """
 
     def __init__(self):
-        _Action.__init__(self, 'NOOP')
+        _Action.__init__(self, "NOOP")
 
 
 class ReceiveChar(_Action):
@@ -491,12 +545,15 @@ class ReceiveChar(_Action):
     """
 
     def __init__(self, timeout=0):
-        _Action.__init__(self, 'RECEIVE CHAR', quote(timeout))
+        _Action.__init__(self, "RECEIVE CHAR", quote(timeout))
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if not result.value == '0':
-            return (_convert_to_char(result.value, response.items), result.data == 'timeout')
+        if not result.value == "0":
+            return (
+                _convert_to_char(result.value, response.items),
+                result.data == "timeout",
+            )
         return None
 
 
@@ -513,7 +570,7 @@ class ReceiveText(_Action):
     """
 
     def __init__(self, timeout=0):
-        _Action.__init__(self, 'RECEIVE TEXT', quote(timeout))
+        _Action.__init__(self, "RECEIVE TEXT", quote(timeout))
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
@@ -526,7 +583,7 @@ class RecordFile(_Action):
     defaulting to Asterisk's sounds path or an absolute path, without extension. ('myfile.wav'
     would be specified as 'myfile') `format` is one of the following, which sets the extension
     and encoding, with WAV being the default:
-    
+
     - FORMAT_SLN
     - FORMAT_G723
     - FORMAT_G729
@@ -539,10 +596,10 @@ class RecordFile(_Action):
     The filename may also contain the special string '%d', which Asterisk will replace with an
     auto-incrementing number, with the resulting filename appearing in the 'RECORDED_FILE'
     channel variable.
-    
+
     `escape_digits` may optionally be a list of DTMF digits, specified as a string or a sequence
     of possibly mixed ints and strings. Playback ends immediately when one is received.
-    
+
     `timeout` is the number of milliseconds to wait following the end of playback if no keys
     were pressed to end recording prior to that point. By default, it waits forever.
 
@@ -552,49 +609,69 @@ class RecordFile(_Action):
 
     `silence`, if given, is the number of seconds of silence to allow before terminating
     recording early.
-    
+
     The value returned is a tuple consisting of (dtmf_key:str, offset:int, timeout:bool), where
     the offset is the number of milliseconds that elapsed since the start of playback dtmf_key
     may be the empty string if no key was pressed, and timeout is `False` if recording ended due
     to another condition (DTMF or silence).
-    
+
     The raising of `AGIResultHangup` is another condition that signals a successful recording,
     though it also means the user hung up.
-    
+
     `AGIAppError` is raised on failure, most commonly because the destination file isn't
     writable.
     """
 
-    def __init__(self, filename, format=FORMAT_WAV, escape_digits='', timeout=-1, sample_offset=0, beep=True,
-                 silence=None):
+    def __init__(
+        self,
+        filename,
+        format=FORMAT_WAV,
+        escape_digits="",
+        timeout=-1,
+        sample_offset=0,
+        beep=True,
+        silence=None,
+    ):
         escape_digits = _process_digit_list(escape_digits)
-        _Action.__init__(self,
-                         'RECORD FILE', quote(filename), quote(format),
-                         quote(escape_digits), quote(timeout), quote(sample_offset),
-                         (beep and quote('beep') or None),
-                         (silence and quote('s=' + str(silence)) or None)
-                         )
+        _Action.__init__(
+            self,
+            "RECORD FILE",
+            quote(filename),
+            quote(format),
+            quote(escape_digits),
+            quote(timeout),
+            quote(sample_offset),
+            (beep and quote("beep") or None),
+            (silence and quote("s=" + str(silence)) or None),
+        )
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
         offset = _convert_to_int(response.items)
 
-        if result.data == 'randomerror':
-            raise AGIAppError("Unknown error occurred %(ms)i into recording: %(error)s" % {
-                'ms': offset,
-                'error': result.value,
-            })
-        elif result.data == 'timeout':
-            return ('', offset, True)
-        elif result.data == 'dtmf':
+        if result.data == "randomerror":
+            raise AGIAppError(
+                "Unknown error occurred %(ms)i into recording: %(error)s"
+                % {
+                    "ms": offset,
+                    "error": result.value,
+                }
+            )
+        elif result.data == "timeout":
+            return ("", offset, True)
+        elif result.data == "dtmf":
             return (_convert_to_char(result.value, response.items), offset, False)
-        return ('', offset, True)  # Assume a timeout if any other result data is received.
+        return (
+            "",
+            offset,
+            True,
+        )  # Assume a timeout if any other result data is received.
 
 
 class _SayAction(_Action):
     """
     A specialised subclass of `_Action` that provides behaviour common to several children.
-    
+
     Synthesises speech on a channel. This abstracts the commonalities between the "SAY ?"
     subclasses.
 
@@ -611,14 +688,14 @@ class _SayAction(_Action):
 
     def __init__(self, say_type, argument, escape_digits, *args):
         escape_digits = _process_digit_list(escape_digits)
-        _Action.__init__(self,
-                         'SAY ' + say_type, quote(argument), quote(escape_digits), *args
-                         )
+        _Action.__init__(
+            self, "SAY " + say_type, quote(argument), quote(escape_digits), *args
+        )
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
 
-        if not result.value == '0':
+        if not result.value == "0":
             return _convert_to_char(result.value, response.items)
         return None
 
@@ -635,16 +712,16 @@ class SayAlpha(_SayAction):
     hung-up.
     """
 
-    def __init__(self, characters, escape_digits=''):
+    def __init__(self, characters, escape_digits=""):
         characters = _process_digit_list(characters)
-        _SayAction.__init__(self, 'ALPHA', characters, escape_digits)
+        _SayAction.__init__(self, "ALPHA", characters, escape_digits)
 
 
 class SayDate(_SayAction):
     """
     Reads the date associated with `seconds` since the UNIX Epoch. If not given, the local time
     is used.
-    
+
     `escape_digits` may optionally be a list of DTMF digits, specified as a string or a sequence
     of possibly mixed ints and strings. Playback ends immediately when one is received and it is
     returned. If nothing is recieved, `None` is returned.
@@ -653,24 +730,24 @@ class SayDate(_SayAction):
     hung-up.
     """
 
-    def __init__(self, seconds=None, escape_digits=''):
+    def __init__(self, seconds=None, escape_digits=""):
         if seconds is None:
             seconds = int(time.time())
-        _SayAction.__init__(self, 'DATE', seconds, escape_digits)
+        _SayAction.__init__(self, "DATE", seconds, escape_digits)
 
 
 class SayDatetime(_SayAction):
     """
     Reads the datetime associated with `seconds` since the UNIX Epoch. If not given, the local
     time is used.
-    
+
     `escape_digits` may optionally be a list of DTMF digits, specified as a string or a sequence
     of possibly mixed ints and strings. Playback ends immediately when one is received and it is
     returned. If nothing is recieved, `None` is returned.
 
     `format` defaults to `"ABdY 'digits/at' IMp"`, but may be a string with any of the following
     meta-characters (or single-quote-escaped sound-file references):
-    
+
     - A: Day of the week
     - B: Month (Full Text)
     - m: Month (Numeric)
@@ -687,20 +764,24 @@ class SayDatetime(_SayAction):
 
     `timezone` may be a string in standard UNIX form, like 'America/Edmonton'. If `format` is
     undefined, `timezone` is ignored and left to default to the system's local value.
-    
+
     `AGIAppError` is raised on failure, most commonly because the channel was
     hung-up.
     """
 
-    def __init__(self, seconds=None, escape_digits='', format=None, timezone=None):
+    def __init__(self, seconds=None, escape_digits="", format=None, timezone=None):
         if seconds is None:
             seconds = int(time.time())
         if not format:
             timezone = None
-        _SayAction.__init__(self,
-                            'DATETIME', seconds, escape_digits,
-                            (format and quote(format) or None), (timezone and quote(timezone) or None)
-                            )
+        _SayAction.__init__(
+            self,
+            "DATETIME",
+            seconds,
+            escape_digits,
+            (format and quote(format) or None),
+            (timezone and quote(timezone) or None),
+        )
 
 
 class SayDigits(_SayAction):
@@ -715,9 +796,9 @@ class SayDigits(_SayAction):
     hung-up.
     """
 
-    def __init__(self, digits, escape_digits=''):
+    def __init__(self, digits, escape_digits=""):
         digits = _process_digit_list(digits)
-        _SayAction.__init__(self, 'DIGITS', digits, escape_digits)
+        _SayAction.__init__(self, "DIGITS", digits, escape_digits)
 
 
 class SayNumber(_SayAction):
@@ -732,9 +813,9 @@ class SayNumber(_SayAction):
     hung-up.
     """
 
-    def __init__(self, number, escape_digits=''):
+    def __init__(self, number, escape_digits=""):
         number = _process_digit_list(number)
-        _SayAction.__init__(self, 'NUMBER', number, escape_digits)
+        _SayAction.__init__(self, "NUMBER", number, escape_digits)
 
 
 class SayPhonetic(_SayAction):
@@ -749,16 +830,16 @@ class SayPhonetic(_SayAction):
     hung-up.
     """
 
-    def __init__(self, characters, escape_digits=''):
+    def __init__(self, characters, escape_digits=""):
         characters = _process_digit_list(characters)
-        _SayAction.__init__(self, 'PHONETIC', characters, escape_digits)
+        _SayAction.__init__(self, "PHONETIC", characters, escape_digits)
 
 
 class SayTime(_SayAction):
     """
     Reads the time associated with `seconds` since the UNIX Epoch. If not given, the local
     time is used.
-    
+
     `escape_digits` may optionally be a list of DTMF digits, specified as a string or a sequence
     of possibly mixed ints and strings. Playback ends immediately when one is received and it is
     returned. If nothing is received, `None` is returned.
@@ -767,10 +848,10 @@ class SayTime(_SayAction):
     hung-up.
     """
 
-    def __init__(self, seconds=None, escape_digits=''):
+    def __init__(self, seconds=None, escape_digits=""):
         if seconds is None:
             seconds = int(time.time())
-        _SayAction.__init__(self, 'TIME', seconds, escape_digits)
+        _SayAction.__init__(self, "TIME", seconds, escape_digits)
 
 
 class SendImage(_Action):
@@ -784,7 +865,7 @@ class SendImage(_Action):
     """
 
     def __init__(self, filename):
-        _Action.__init__(self, 'SEND FILE', quote(filename))
+        _Action.__init__(self, "SEND FILE", quote(filename))
 
 
 class SendText(_Action):
@@ -795,7 +876,7 @@ class SendText(_Action):
     """
 
     def __init__(self, text):
-        _Action.__init__(self, 'SEND TEXT', quote(text))
+        _Action.__init__(self, "SEND TEXT", quote(text))
 
 
 class SetAutohangup(_Action):
@@ -808,7 +889,7 @@ class SetAutohangup(_Action):
     """
 
     def __init__(self, seconds=0):
-        _Action.__init__(self, 'SET AUTOHANGUP', quote(seconds))
+        _Action.__init__(self, "SET AUTOHANGUP", quote(seconds))
 
 
 class SetCallerid(_Action):
@@ -821,43 +902,43 @@ class SetCallerid(_Action):
     def __init__(self, number, name=None):
         if name:  # Escape it
             name = '\\"%(name)s\\"' % {
-                'name': name,
+                "name": name,
             }
         else:  # Make sure it's the empty string
-            name = ''
+            name = ""
         number = "%(name)s<%(number)s>" % {
-            'name': name,
-            'number': number,
+            "name": name,
+            "number": number,
         }
-        _Action.__init__(self, 'SET CALLERID', quote(number))
+        _Action.__init__(self, "SET CALLERID", quote(number))
 
 
 class SetContext(_Action):
     """
     Sets the context for Asterisk to use upon completion of this AGI instance.
-    
+
     No context-validation is performed; specifying an invalid context will cause the call to
     terminate unexpectedly.
-    
+
     `AGIAppError` is raised on failure.
     """
 
     def __init__(self, context):
-        _Action.__init__(self, 'SET CONTEXT', quote(context))
+        _Action.__init__(self, "SET CONTEXT", quote(context))
 
 
 class SetExtension(_Action):
     """
     Sets the extension for Asterisk to use upon completion of this AGI instance.
-    
+
     No extension-validation is performed; specifying an invalid extension will cause the call to
     terminate unexpectedly.
-    
+
     `AGIAppError` is raised on failure.
     """
 
     def __init__(self, extension):
-        _Action.__init__(self, 'SET EXTENSION', quote(extension))
+        _Action.__init__(self, "SET EXTENSION", quote(extension))
 
 
 class SetMusic(_Action):
@@ -865,29 +946,31 @@ class SetMusic(_Action):
     Enables or disables music-on-hold for this channel, per the state of the `on` argument.
 
     If specified, `moh_class` identifies the music-on-hold class to be used.
-    
+
     `AGIAppError` is raised on failure.
     """
 
     def __init__(self, on, moh_class=None):
-        _Action.__init__(self,
-                         'SET MUSIC', quote(on and 'on' or 'off'),
-                         (moh_class and quote(moh_class) or None)
-                         )
+        _Action.__init__(
+            self,
+            "SET MUSIC",
+            quote(on and "on" or "off"),
+            (moh_class and quote(moh_class) or None),
+        )
 
 
 class SetPriority(_Action):
     """
     Sets the priority for Asterisk to use upon completion of this AGI instance.
-    
+
     No priority-validation is performed; specifying an invalid priority will cause the call to
     terminate unexpectedly.
-    
+
     `AGIAppError` is raised on failure.
     """
 
     def __init__(self, priority):
-        _Action.__init__(self, 'SET PRIORITY', quote(priority))
+        _Action.__init__(self, "SET PRIORITY", quote(priority))
 
 
 class SetVariable(_Action):
@@ -898,7 +981,7 @@ class SetVariable(_Action):
     """
 
     def __init__(self, name, value):
-        _Action.__init__(self, 'SET VARIABLE', quote(name), quote(value))
+        _Action.__init__(self, "SET VARIABLE", quote(name), quote(value))
 
 
 class StreamFile(_Action):
@@ -909,30 +992,33 @@ class StreamFile(_Action):
     an Asterisk-searched directory or as an absolute path, without extension. ('myfile.wav'
     would be specified as 'myfile', to allow Asterisk to choose the most efficient encoding,
     based on extension, for the channel)
-    
+
     `escape_digits` may optionally be a list of DTMF digits, specified as a string or a sequence
     of possibly mixed ints and strings. Playback ends immediately when one is received.
-    
+
     `sample_offset` may be used to jump an arbitrary number of milliseconds into the audio data.
-    
+
     The value returned is a tuple consisting of (dtmf_key:str, offset:int), where the offset is
     the number of milliseconds that elapsed since the start of playback, or None if playback
     completed successfully or the sample could not be opened.
-    
+
     `AGIAppError` is raised on failure, most commonly because the channel was
     hung-up.
     """
 
-    def __init__(self, filename, escape_digits='', sample_offset=0):
+    def __init__(self, filename, escape_digits="", sample_offset=0):
         escape_digits = _process_digit_list(escape_digits)
-        _Action.__init__(self,
-                         'STREAM FILE', quote(filename),
-                         quote(escape_digits), quote(sample_offset)
-                         )
+        _Action.__init__(
+            self,
+            "STREAM FILE",
+            quote(filename),
+            quote(escape_digits),
+            quote(sample_offset),
+        )
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if not result.value == '0':
+        if not result.value == "0":
             dtmf_character = _convert_to_char(result.value, response.items)
             offset = _convert_to_int(response.items)
             return (dtmf_character, offset)
@@ -942,22 +1028,22 @@ class StreamFile(_Action):
 class TDDMode(_Action):
     """
     Sets the TDD transmission `mode` on supporting channels, one of the following:
-    
+
     - TDD_ON
     - TDD_OFF
     - TDD_MATE
-    
+
     `True` is returned if the mode is set, `False` if the channel isn't capable, and
     `AGIAppError` is raised if a problem occurs. According to documentation from 2006,
     all non-capable channels will cause an exception to occur.
     """
 
     def __init__(self, mode):
-        _Action.__init__(self, 'TDD MODE', mode)
+        _Action.__init__(self, "TDD MODE", mode)
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        return result.value == '1'
+        return result.value == "1"
 
 
 class Verbose(_Action):
@@ -965,20 +1051,20 @@ class Verbose(_Action):
     Causes Asterisk to process `message`, logging it to console or disk,
     depending on whether `level` is greater-than-or-equal-to Asterisk's
     corresponding verbosity threshold.
-    
+
     `level` is one of the following, defaulting to LOG_INFO:
-    
+
     - LOG_DEBUG
     - LOG_INFO
     - LOG_WARN
     - LOG_ERROR
     - LOG_CRITICAL
-    
+
     `AGIAppError` is raised on failure.
     """
 
     def __init__(self, message, level=LOG_INFO):
-        _Action.__init__(self, 'VERBOSE', quote(message), quote(level))
+        _Action.__init__(self, "VERBOSE", quote(message), quote(level))
 
 
 class WaitForDigit(_Action):
@@ -987,17 +1073,17 @@ class WaitForDigit(_Action):
     value. By default, this function blocks indefinitely.
 
     If no DTMF key is pressed, `None` is returned.
-    
+
     `AGIAppError` is raised on failure, most commonly because the channel was
     hung-up.
     """
 
     def __init__(self, timeout=-1):
-        _Action.__init__(self, 'WAIT FOR DIGIT', quote(timeout))
+        _Action.__init__(self, "WAIT FOR DIGIT", quote(timeout))
 
     def process_response(self, response):
         result = response.items.get(_RESULT_KEY)
-        if not result.value == '0':
+        if not result.value == "0":
             return _convert_to_char(result.value, response.items)
         return None
 

--- a/pystrix/agi/fastagi.py
+++ b/pystrix/agi/fastagi.py
@@ -28,22 +28,23 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU General Public License and
 GNU Lesser General Public License along with this program. If not, see
 <http://www.gnu.org/licenses/>.
- 
+
 (C) Ivrnet, inc., 2011
 
 Authors:
 
 - Neil Tallim <n.tallim@ivrnet.com>
 """
+
 import platform
 import socket
+import socketserver
 import subprocess
 import threading
 from urllib.parse import parse_qs
+
 from pystrix.agi.agi_core import *
 from pystrix.agi.agi_core import _AGI
-
-import socketserver
 
 
 class _ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
@@ -89,6 +90,7 @@ class _AGIClientHandler(socketserver.StreamRequestHandler):
     """
     Handles TCP connections.
     """
+
     def handle(self):
         """
         Creates an instance of an AGI-interface object and passes it to a pre-specified callable,
@@ -98,7 +100,7 @@ class _AGIClientHandler(socketserver.StreamRequestHandler):
 
         (path, kwargs) = self._extract_query_elements(agi_instance)
         args = self._extract_positional_args(agi_instance)
-        
+
         (handler, match) = self.server.get_script_handler(path)
         if handler:
             handler(agi_instance, args, kwargs, match, path)
@@ -109,8 +111,8 @@ class _AGIClientHandler(socketserver.StreamRequestHandler):
         the specification by which they're supplied may change in the future.
         """
         env = agi_instance.get_environment()
-        keys = sorted((int(key[8:]) for key in env if key.startswith('agi_arg_')))
-        return tuple((env['agi_arg_%i' % key] for key in keys))
+        keys = sorted((int(key[8:]) for key in env if key.startswith("agi_arg_")))
+        return tuple((env["agi_arg_%i" % key] for key in keys))
 
     def _extract_query_elements(self, agi_instance):
         """
@@ -118,29 +120,37 @@ class _AGIClientHandler(socketserver.StreamRequestHandler):
         request. Arguments are supplied as a list, since the same parameter may be specified
         multiple times.
         """
-        tokens = (agi_instance.get_environment().get('agi_network_script') or '/').split('?', 1)
+        tokens = (
+            agi_instance.get_environment().get("agi_network_script") or "/"
+        ).split("?", 1)
         path = tokens[0]
         if len(tokens) == 1:
             return (path, {})
         return (path, parse_qs(tokens[1]))
 
+
 class FastAGIServer(_ThreadedTCPServer):
     """
     Provides a FastAGI TCP server to handle requests from Asterisk servers.
     """
-    debug = False #Used to enable various printouts for library development
-    _default_script_handler = None #A script-handler to use if nothing else matched
-    _script_handlers = None #A list of regex/callable pairs to use when determining how to handle an AGI request
-    _script_handlers_lock = None #A lock used to prevent race conditions on the handlers list
-    
-    def __init__(self, interface='127.0.0.1', port=4573, daemon_threads=True, debug=False):
+
+    debug = False  # Used to enable various printouts for library development
+    _default_script_handler = None  # A script-handler to use if nothing else matched
+    _script_handlers = None  # A list of regex/callable pairs to use when determining how to handle an AGI request
+    _script_handlers_lock = (
+        None  # A lock used to prevent race conditions on the handlers list
+    )
+
+    def __init__(
+        self, interface="127.0.0.1", port=4573, daemon_threads=True, debug=False
+    ):
         """
         Creates the server and binds the client-handler callable.
-        
+
         `interface` is the address of the interface on which to listen; defaults
         to localhost, but may be any interface on the host or `'0.0.0.0'` for
         all. `port` is the TCP port on which to listen.
-        
+
         `daemon_threads` indicates whether any threads spawned to handle
         requests should be killed if the main thread dies. (Generally a good
         idea to avoid hung calls keeping the process alive forever)
@@ -169,7 +179,7 @@ class FastAGIServer(_ThreadedTCPServer):
         `script_path` is the path received from Asterisk.
         """
         with self._script_handlers_lock:
-            for (regex, handler) in self._script_handlers:
+            for regex, handler in self._script_handlers:
                 match = None
                 if isinstance(regex, str):
                     match = re.match(regex, script_path)
@@ -177,7 +187,7 @@ class FastAGIServer(_ThreadedTCPServer):
                     match = regex.match(script_path)
                 if match:
                     return (handler, match)
-                    
+
             return (self._default_script_handler, None)
 
     def register_script_handler(self, regex, handler):
@@ -200,12 +210,12 @@ class FastAGIServer(_ThreadedTCPServer):
                 self._default_script_handler = handler
                 return
 
-            #Ensure that the regex hasn't been registered before
-            for (old_regex, old_handler) in self._script_handlers:
+            # Ensure that the regex hasn't been registered before
+            for old_regex, old_handler in self._script_handlers:
                 if old_regex == regex:
                     return
 
-            #Add the handler to the end of the list
+            # Add the handler to the end of the list
             self._script_handlers.append((regex, handler))
 
     def unregister_script_handler(self, regex):
@@ -218,16 +228,18 @@ class FastAGIServer(_ThreadedTCPServer):
         handlers in the desired order.
         """
         with self._script_handlers_lock:
-            for (i, (old_regex, old_handler)) in enumerate(self._script_handlers):
+            for i, (old_regex, old_handler) in enumerate(self._script_handlers):
                 if old_regex == regex:
                     self._script_handlers.pop(i)
                     break
+
 
 class FastAGI(_AGI):
     """
     An interface to Asterisk, exposing request-response functions for
     synchronous management of the call associated with this channel.
     """
+
     def __init__(self, rfile, wfile, debug=False):
         """
         Associates I/O with `rfile` and `wfile`.
@@ -236,6 +248,5 @@ class FastAGI(_AGI):
         """
         self._rfile = rfile
         self._wfile = wfile
-        
+
         _AGI.__init__(self, debug)
-        

--- a/pystrix/ami/__init__.py
+++ b/pystrix/ami/__init__.py
@@ -34,33 +34,42 @@ Authors:
 
 - Neil Tallim <n.tallim@ivrnet.com>
 """
-from pystrix.ami.ami import (
- RESPONSE_GENERIC, EVENT_GENERIC,
- KEY_ACTION, KEY_ACTIONID, KEY_EVENT, KEY_RESPONSE,
- Manager,
- Error, ManagerError, ManagerSocketError,
-)
-
-from pystrix.ami import core
-from pystrix.ami import dahdi
-from pystrix.ami import app_confbridge
-from pystrix.ami import app_meetme
 
 # Register events
-from pystrix.ami import core_events
-from pystrix.ami import dahdi_events
-from pystrix.ami import app_confbridge_events
-from pystrix.ami import app_meetme_events
+from pystrix.ami import (
+    app_confbridge,
+    app_confbridge_events,
+    app_meetme,
+    app_meetme_events,
+    core,
+    core_events,
+    dahdi,
+    dahdi_events,
+)
+from pystrix.ami.ami import (
+    _EVENT_REGISTRY,
+    _EVENT_REGISTRY_REV,
+    EVENT_GENERIC,
+    KEY_ACTION,
+    KEY_ACTIONID,
+    KEY_EVENT,
+    KEY_RESPONSE,
+    RESPONSE_GENERIC,
+    Error,
+    Manager,
+    ManagerError,
+    ManagerSocketError,
+)
 
-from pystrix.ami.ami import (_EVENT_REGISTRY, _EVENT_REGISTRY_REV)
 for module in (
- core_events, dahdi_events,
- app_confbridge_events, app_meetme_events,
+    core_events,
+    dahdi_events,
+    app_confbridge_events,
+    app_meetme_events,
 ):
-    for event in (e for e in dir(module) if not e.startswith('_')):
+    for event in (e for e in dir(module) if not e.startswith("_")):
         class_object = getattr(module, event)
         _EVENT_REGISTRY[event] = class_object
         _EVENT_REGISTRY_REV[class_object] = event
 del _EVENT_REGISTRY
 del _EVENT_REGISTRY_REV
-

--- a/pystrix/ami/ami.py
+++ b/pystrix/ami/ami.py
@@ -32,8 +32,10 @@ Authors:
 
 - Neil Tallim <flan@uguu.ca>
 """
+
 import abc
 import collections
+import queue
 import random
 import re
 import socket
@@ -42,73 +44,100 @@ import time
 import traceback
 import warnings
 
-import queue
-
 from pystrix.ami import generic_transforms
 
-_EVENT_REGISTRY = {} #Meant to be internally managed only, this provides mappings from event-class-names to the classes, to enable type-mutation
-_EVENT_REGISTRY_REV = {} #Provides the friendly names of events as strings, keyed by class object
+_EVENT_REGISTRY = {}  # Meant to be internally managed only, this provides mappings from event-class-names to the classes, to enable type-mutation
+_EVENT_REGISTRY_REV = {}  # Provides the friendly names of events as strings, keyed by class object
 
-_EOC = '--END COMMAND--' #A string used by Asterisk to mark the end of some of its responses.
-_EOL = '\r\n' #Asterisk uses CRLF linebreaks to mark the ends of its lines.
-_EOL_FAKE = ('\n\r\n', '\r\r\n') #End-of-line patterns that indicate data, not headers.
+_EOC = "--END COMMAND--"  # A string used by Asterisk to mark the end of some of its responses.
+_EOL = "\r\n"  # Asterisk uses CRLF linebreaks to mark the ends of its lines.
+_EOL_FAKE = (
+    "\n\r\n",
+    "\r\r\n",
+)  # End-of-line patterns that indicate data, not headers.
 
-_EOC_INDICATOR = re.compile(r'Response:\s*Follows\s*$') #A regular expression that matches response headers that indicate the payload is attached
+_EOC_INDICATOR = re.compile(
+    r"Response:\s*Follows\s*$"
+)  # A regular expression that matches response headers that indicate the payload is attached
 
-_Response = collections.namedtuple('Response', [
- 'result', 'response', 'request', 'action_id', 'success', 'time', 'events', 'events_timeout',
-]) #A container for responses to requests.
+_Response = collections.namedtuple(
+    "Response",
+    [
+        "result",
+        "response",
+        "request",
+        "action_id",
+        "success",
+        "time",
+        "events",
+        "events_timeout",
+    ],
+)  # A container for responses to requests.
 
-RESPONSE_GENERIC = 'Generic Response' #A header-value provided as a surrogate for unidentifiable responses
-EVENT_GENERIC = 'Generic Event' #A header-value provided as a surrogate for unidentifiable unsolicited events
+RESPONSE_GENERIC = "Generic Response"  # A header-value provided as a surrogate for unidentifiable responses
+EVENT_GENERIC = "Generic Event"  # A header-value provided as a surrogate for unidentifiable unsolicited events
 
-KEY_ACTION = 'Action' #The key used to identify an action being requested of Asterisk
-KEY_ACTIONID = 'ActionID' #The key used to hold the ActionID of a request, for matching with responses
-KEY_EVENT = 'Event' #The key used to hold the event-name of a response
-KEY_RESPONSE = 'Response' #The key used to hold the event-name of a request
+KEY_ACTION = "Action"  # The key used to identify an action being requested of Asterisk
+KEY_ACTIONID = "ActionID"  # The key used to hold the ActionID of a request, for matching with responses
+KEY_EVENT = "Event"  # The key used to hold the event-name of a response
+KEY_RESPONSE = "Response"  # The key used to hold the event-name of a request
 
-_CALLBACK_TYPE_REFERENCE = 1 #Identifies a callback-definition as an event-reference
-_CALLBACK_TYPE_UNIVERSAL = 2 #Identifies a callback-definition as universal
-_CALLBACK_TYPE_ORPHANED = 3 #Identifies a callback-definition for orphaned responses
+_CALLBACK_TYPE_REFERENCE = 1  # Identifies a callback-definition as an event-reference
+_CALLBACK_TYPE_UNIVERSAL = 2  # Identifies a callback-definition as universal
+_CALLBACK_TYPE_ORPHANED = 3  # Identifies a callback-definition for orphaned responses
+
 
 def _format_socket_error(exception):
     """
     Ensures that, regardless of the form that a `socket.error` takes, it is
     formatted into a readable string.
-    
+
     @param str exception: The `socket.error` to be formatted.
     @return str: A nicely formatted summary of the exception.
     """
     try:
         (errno, message) = exception
         return "[%(errno)i] %(error)s" % {
-         'errno': errno,
-         'error': message,
+            "errno": errno,
+            "error": message,
         }
     except Exception:
         return str(exception)
-        
+
+
 class Manager:
-    _alive = True #False when this manager object is ready to be disposed of
-    _action_id = None #The ActionID last sent to Asterisk
-    _action_id_random_token = None #A randomly generated token, used to help avoid conflicts when multiple AMI connections are in use
-    _action_id_lock = None #A lock used to prevent race conditions on ActionIDs
-    _connection = None #A connection to the Asterisk manager, realised as a `_SynchronisedSocket`
-    _connection_lock = None #A means of preventing race conditions on the connection
-    _debug = False #If True, development information is emitted along the normal logging stream
-    _event_aggregates = None #A list of aggregates awaiting fulfillment
-    _event_aggregates_lock = None #A lock used to prevent race conditions on event aggregation
-    _event_aggregates_timeout = None #The amount of time to wait before considering an aggregate timed-out
-    _event_callbacks = None #A list of tuples of type-identifiers, match-criteria, and callback functions
-    _event_callbacks_lock = None #A lock used to prevent race conditions on event callbacks
-    _event_callbacks_thread = None #A thread used to process event callbacks
-    _hostname = socket.gethostname() #The hostname of this system, used to prevent repeated calls through the C layer
-    _message_reader = None #A thread that continuously collects messages from the Asterisk server
-    _orphaned_response_timeout = None #The number of seconds to hold on to request-responses before considering them to be timed-out
-    _outstanding_requests = None #A dictionary of ActionIDs sent to Asterisk, currently awaiting responses; values are a tuple of (events, pending_finalisers), if synchronous, and None otherwise
-    _logger = None #A logger that may be used to record warnings
-    
-    def __init__(self, debug=False, logger=None, aggregate_timeout=5, orphaned_response_timeout=5):
+    _alive = True  # False when this manager object is ready to be disposed of
+    _action_id = None  # The ActionID last sent to Asterisk
+    _action_id_random_token = None  # A randomly generated token, used to help avoid conflicts when multiple AMI connections are in use
+    _action_id_lock = None  # A lock used to prevent race conditions on ActionIDs
+    _connection = None  # A connection to the Asterisk manager, realised as a `_SynchronisedSocket`
+    _connection_lock = None  # A means of preventing race conditions on the connection
+    _debug = False  # If True, development information is emitted along the normal logging stream
+    _event_aggregates = None  # A list of aggregates awaiting fulfillment
+    _event_aggregates_lock = (
+        None  # A lock used to prevent race conditions on event aggregation
+    )
+    _event_aggregates_timeout = (
+        None  # The amount of time to wait before considering an aggregate timed-out
+    )
+    _event_callbacks = None  # A list of tuples of type-identifiers, match-criteria, and callback functions
+    _event_callbacks_lock = (
+        None  # A lock used to prevent race conditions on event callbacks
+    )
+    _event_callbacks_thread = None  # A thread used to process event callbacks
+    _hostname = (
+        socket.gethostname()
+    )  # The hostname of this system, used to prevent repeated calls through the C layer
+    _message_reader = (
+        None  # A thread that continuously collects messages from the Asterisk server
+    )
+    _orphaned_response_timeout = None  # The number of seconds to hold on to request-responses before considering them to be timed-out
+    _outstanding_requests = None  # A dictionary of ActionIDs sent to Asterisk, currently awaiting responses; values are a tuple of (events, pending_finalisers), if synchronous, and None otherwise
+    _logger = None  # A logger that may be used to record warnings
+
+    def __init__(
+        self, debug=False, logger=None, aggregate_timeout=5, orphaned_response_timeout=5
+    ):
         """
         Sets up an environment for interacting with an Asterisk Management Interface.
 
@@ -117,10 +146,10 @@ class Manager:
 
         `logger` may be a logging.Logger object to use for logging problems in AMI threads. If not
         provided, problems will be emitted through the Python warnings interface.
-        
+
         `aggregate_timeout` is the number of seconds to wait for aggregates to be fully assembled
         before considering them timed-out.
-        
+
         `orphaned_response_timeout` is the number of seconds to wait for responses to requests to be
         collected before considering them timed out. (This should never happen, but a guarantee must
         be made that the buffer can stay clean)
@@ -129,18 +158,18 @@ class Manager:
         """
         self._debug = debug
         self._logger = logger
-        
+
         self._action_id = 0
         action_id_random_token = []
         for i in range(5):
-            if random.random() < 0.25: #Append a digit
+            if random.random() < 0.25:  # Append a digit
                 action_id_random_token.append(chr(random.randint(48, 57)))
             else:
-                if random.random() < 0.5: #Append a upper-case letter
+                if random.random() < 0.5:  # Append a upper-case letter
                     action_id_random_token.append(chr(random.randint(65, 90)))
-                else: #Append a lower-case letter
+                else:  # Append a lower-case letter
                     action_id_random_token.append(chr(random.randint(97, 122)))
-        self._action_id_random_token = ''.join(action_id_random_token)
+        self._action_id_random_token = "".join(action_id_random_token)
         self._action_id_lock = threading.Lock()
 
         self._connection_lock = threading.Lock()
@@ -157,7 +186,7 @@ class Manager:
         self._event_callbacks_thread = threading.Thread(target=self._event_dispatcher)
         self._event_callbacks_thread.daemon = True
         self._event_callbacks_thread.start()
-        
+
     def __del__(self):
         """
         Ensure that all resources are freed quickly upon garbage-collection.
@@ -174,43 +203,50 @@ class Manager:
         event_aggregates_complete = collections.deque()
         event_aggregate_cycle = 0
         while self._alive:
-            #Determine whether there's actually anything to read from
+            # Determine whether there's actually anything to read from
             message_reader = None
             with self._connection_lock:
                 message_reader = self._message_reader
             if not message_reader:
                 time.sleep(0.02)
                 continue
-                
-            #Emit events, sleeping if nothing was sent during this cycle
-            sleep = not self._event_dispatcher_events(message_reader, event_aggregates_complete)
-            sleep = not self._event_dispatcher_orphaned_responses(message_reader) and sleep
+
+            # Emit events, sleeping if nothing was sent during this cycle
+            sleep = not self._event_dispatcher_events(
+                message_reader, event_aggregates_complete
+            )
+            sleep = (
+                not self._event_dispatcher_orphaned_responses(message_reader) and sleep
+            )
             if sleep:
                 time.sleep(0.02)
-                #Clean up old aggregates about once every second
+                # Clean up old aggregates about once every second
                 if event_aggregate_cycle == 0:
                     event_aggregate_cycle = 50
                     current_time = time.time()
                     with self._event_aggregates_lock:
-                        for (i, aggregate) in enumerate(self._event_aggregates):
-                            if aggregate[0] <= current_time: #Expired
+                        for i, aggregate in enumerate(self._event_aggregates):
+                            if aggregate[0] <= current_time:  # Expired
                                 del self._event_aggregates[i]
-                                (self._logger and self._logger.warn or warnings.warn)("Aggregate '%(name)s' for action-ID '%(action-id)s' timed out before all events were gathered" % {
-                                 'name': aggregate[1].name,
-                                 'action-id': aggregate[1].action_id,
-                                })
+                                (self._logger and self._logger.warn or warnings.warn)(
+                                    "Aggregate '%(name)s' for action-ID '%(action-id)s' timed out before all events were gathered"
+                                    % {
+                                        "name": aggregate[1].name,
+                                        "action-id": aggregate[1].action_id,
+                                    }
+                                )
                 else:
                     event_aggregate_cycle -= 1
-                    
+
     def _event_dispatcher_events(self, message_reader, event_aggregates_complete):
         """
         Pulls events from the message-reader, then sends them to all registered callbacks. The
         returned value indicates whether anything was done during the current cycle.
-        
+
         If aggregates are in use, they are assembled and broadcast here, as well.
         """
         event = None
-        if event_aggregates_complete: #Check for completed aggregates first
+        if event_aggregates_complete:  # Check for completed aggregates first
             event = event_aggregates_complete.popleft()
         else:
             try:
@@ -218,50 +254,61 @@ class Manager:
             except queue.Empty:
                 pass
             else:
-                #Bind it to a request, if appropriate
+                # Bind it to a request, if appropriate
                 if self._process_outstanding_request_event(event):
-                    return #Synchronous requests do not generate asynchronous events
-                    
-                #Evaluate the new event against all pending aggregates
+                    return  # Synchronous requests do not generate asynchronous events
+
+                # Evaluate the new event against all pending aggregates
                 with self._event_aggregates_lock:
-                    for (i, (_, aggregate)) in enumerate(self._event_aggregates):
+                    for i, (_, aggregate) in enumerate(self._event_aggregates):
                         aggregation_result = aggregate.evaluate_event(event)
-                        if aggregation_result is None: #Not relevant
+                        if aggregation_result is None:  # Not relevant
                             continue
                         else:
-                            if aggregation_result: #Finalised
+                            if aggregation_result:  # Finalised
                                 event_aggregates_complete.append(aggregate)
                                 del self._event_aggregates[i]
                             break
-        
+
         if event:
             event_name = event.name
             callbacks = None
             global _CALLBACK_TYPE_REFERENCE
             global _CALLBACK_TYPE_UNIVERSAL
             with self._event_callbacks_lock:
-                callbacks = [c for (t, e, c) in self._event_callbacks if (t == _CALLBACK_TYPE_REFERENCE and event_name == e) or (t == _CALLBACK_TYPE_UNIVERSAL)]
-                
+                callbacks = [
+                    c
+                    for (t, e, c) in self._event_callbacks
+                    if (t == _CALLBACK_TYPE_REFERENCE and event_name == e)
+                    or (t == _CALLBACK_TYPE_UNIVERSAL)
+                ]
+
             if self._logger:
-                self._logger.debug("Received event '%(name)s' with %(callbacks)i callbacks" % {
-                 'name': event_name,
-                 'callbacks': len(callbacks),
-                })
-                
+                self._logger.debug(
+                    "Received event '%(name)s' with %(callbacks)i callbacks"
+                    % {
+                        "name": event_name,
+                        "callbacks": len(callbacks),
+                    }
+                )
+
             for callback in callbacks:
                 try:
                     callback(event, self)
                 except Exception as e:
-                    (self._logger and self._logger.error or warnings.warn)("Exception occurred while processing event callback: event='%(event)r'; handler='%(function)s' exception: %(error)s; trace:\n%(trace)s" % {
-                     'event': event,
-                     'function': str(callback),
-                     'error': str(e),
-                     'trace': traceback.format_exc(),
-                    })
-                    
+                    (self._logger and self._logger.error or warnings.warn)(
+                        "Exception occurred while processing event callback: event='%(event)r'; handler='%(function)s' exception: %(error)s; trace:\n%(trace)s"
+                        % {
+                            "event": event,
+                            "function": str(callback),
+                            "error": str(e),
+                            "trace": traceback.format_exc(),
+                        }
+                    )
+
             return True
         return False
-        
+
     def _event_dispatcher_orphaned_responses(self, message_reader):
         """
         Pulls orphaned responses from the message-reader, then sends them to orhpan-handler
@@ -272,33 +319,43 @@ class Manager:
             response = message_reader.response_queue.get_nowait()
         except queue.Empty:
             pass
-            
+
         if response:
             callbacks = None
             global _CALLBACK_TYPE_ORPHANED
             with self._event_callbacks_lock:
-                callbacks = [c for (t, e, c) in self._event_callbacks if t == _CALLBACK_TYPE_ORPHANED]
-                
+                callbacks = [
+                    c
+                    for (t, e, c) in self._event_callbacks
+                    if t == _CALLBACK_TYPE_ORPHANED
+                ]
+
             if self._logger:
-                self._logger.debug("Received orphaned response '%(name)s' with %(callbacks)i callbacks" % {
-                 'name': response.name,
-                 'callbacks': len(callbacks),
-                })
-                
+                self._logger.debug(
+                    "Received orphaned response '%(name)s' with %(callbacks)i callbacks"
+                    % {
+                        "name": response.name,
+                        "callbacks": len(callbacks),
+                    }
+                )
+
             for callback in callbacks:
                 try:
                     callback(response, self)
                 except Exception as e:
-                    (self._logger and self._logger.error or warnings.warn)("Exception occurred while processing orphaned response handler: response=%(response)r; handler='%(function)s'; exception: %(error)s; trace:\n%(trace)s" % {
-                     'response': response,
-                     'function': str(callback),
-                     'error': str(e),
-                     'trace': traceback.format_exc(),
-                    })
-                    
+                    (self._logger and self._logger.error or warnings.warn)(
+                        "Exception occurred while processing orphaned response handler: response=%(response)r; handler='%(function)s'; exception: %(error)s; trace:\n%(trace)s"
+                        % {
+                            "response": response,
+                            "function": str(callback),
+                            "error": str(e),
+                            "trace": traceback.format_exc(),
+                        }
+                    )
+
             return True
         return False
-        
+
     def _get_action_id(self):
         """
         Produces a session-unique int, suitable for passing to Asterisk as an ActionID.
@@ -314,23 +371,23 @@ class Manager:
         Generates a host-qualified, random-token-augmented ActionID as a string, for greater
         identifiability.
         """
-        return '%(hostname)s-%(random)s-%(id)08x' % {
-         'hostname': self._hostname,
-         'random': self._action_id_random_token,
-         'id': self._get_action_id(),
+        return "%(hostname)s-%(random)s-%(id)08x" % {
+            "hostname": self._hostname,
+            "random": self._action_id_random_token,
+            "id": self._get_action_id(),
         }
 
     def close(self):
         """
         Release all resources associated with this manager and ensure that all threads have stopped.
-        
+
         This function is automatically invoked when garbage-collected.
         """
         self.disconnect()
-        
+
         self._alive = False
         self._event_callbacks_thread.join()
-        
+
     def connect(self, host, port=5038, timeout=5):
         """
         Establishes a connection to the specified Asterisk manager, closing any existing connection
@@ -339,29 +396,33 @@ class Manager:
         `timeout` specifies the number of seconds to allow Asterisk to go between producing lines of
         a response; it differs from the timeout that may be set on individual requests and exists
         primarily to avoid having a thread stay active forever, to allow for clean shutdowns.
-        
+
         If the connection fails, `ManagerSocketError` is raised.
         """
         self.disconnect()
         with self._connection_lock:
-            self._connection = _SynchronisedSocket(host=host, port=port, timeout=timeout)
-            
+            self._connection = _SynchronisedSocket(
+                host=host, port=port, timeout=timeout
+            )
+
             self._message_reader = _MessageReader(self, self._orphaned_response_timeout)
             self._message_reader.start()
-            
+
     def disconnect(self):
         """
         Gracefully closes a connection to the Asterisk manager.
-        
+
         If not connected, this is a no-op.
         """
         with self._connection_lock:
-            if self._connection: #Close the old connection, if any.
+            if self._connection:  # Close the old connection, if any.
                 self._connection.close()
                 self._connection = None
             self._outstanding_requests.clear()
-            
-            if self._message_reader: #Kill, but don't drop, the reader, since it may have unprocessed data
+
+            if (
+                self._message_reader
+            ):  # Kill, but don't drop, the reader, since it may have unprocessed data
                 self._message_reader.kill()
 
     def get_asterisk_info(self):
@@ -377,12 +438,12 @@ class Manager:
         """
         Returns the current `_SynchronisedSocket` in use by the active connection, or `None` if no
         manager is attached.
-        
+
         This function is exposed for debugging purposes and should not be used by normal
         applications that do not have very special reasons for interacting with Asterisk directly.
         """
         return self._connection
-        
+
     def is_connected(self):
         """
         Indicates whether the manager is connected.
@@ -394,21 +455,24 @@ class Manager:
         """
         Spawns a thread that watches the AMI connection to indicate a disruption when the connection
         goes down.
-        
+
         `interval` is the number of seconds to wait between automated Pings to see if Asterisk
         is still alive; defaults to 2.5.
         """
+
         def _monitor_connection():
             from pystrix.ami import core
 
             while self.is_connected():
                 self.send_action(core.Ping())
                 time.sleep(interval)
-                
-        monitor = threading.Thread(target=_monitor_connection, name='pystrix-ami-monitor')
+
+        monitor = threading.Thread(
+            target=_monitor_connection, name="pystrix-ami-monitor"
+        )
         monitor.daemon = True
         monitor.start()
-        
+
     def _compile_callback_definition(self, event, function):
         """
         Provides a triple of type, match-criteria, and callback for the given event-identifier and
@@ -424,9 +488,11 @@ class Manager:
                 return (_CALLBACK_TYPE_REFERENCE, event_name, function)
         elif event is None:
             return (_CALLBACK_TYPE_ORPHANED, None, function)
-            
-        raise ValueError("Attempted to build callback definition using an unsupported identifier")
-        
+
+        raise ValueError(
+            "Attempted to build callback definition using an unsupported identifier"
+        )
+
     def register_callback(self, event, function):
         """
         Registers a callback for an Asterisk event identified by `event`, which may be a string for
@@ -435,7 +501,7 @@ class Manager:
         `function` is the callable to be invoked whenever a matching `_Event` is emitted; it must
         accept the positional arguments "event" and "manager", with "event" being the `_Event`
         object and "manager" being a reference to generating instance of this class.
-        
+
         Registering the same function twice for the same event will unset the first callback,
         placing the new one at the end of the list.
 
@@ -452,42 +518,42 @@ class Manager:
         self._unregister_callback(callback_definition)
         with self._event_callbacks_lock:
             self._event_callbacks.append(callback_definition)
-            
+
     def _unregister_callback(self, definition):
         """
         Removes the indicated callback from the list of those registered, if a match is found.
-        
+
         The value returned indicates whether anything was removed.
         """
         with self._event_callbacks_lock:
-            for (i, d) in enumerate(self._event_callbacks):
+            for i, d in enumerate(self._event_callbacks):
                 if definition == d:
                     del self._event_callbacks[i]
                     return True
         return False
-        
+
     def unregister_callback(self, event, function):
         """
         Unregisters a previously bound callback.
-        
+
         A boolean value is returned, indicating whether anything was removed.
         """
         callback_definition = self._compile_callback_definition(event, function)
         return self._unregister_callback(callback_definition)
-        
+
     def send_action(self, request, action_id=None, **kwargs):
         """
         Sends a command, contained in `request`, a `_Request`, to the Asterisk manager, referred to
         interchangeably as "actions". Any additional keyword arguments are added directly into the
         request command as though they were native headers, though the original object is
         unaffected.
-        
+
         `action_id` is an optional Asterisk ActionID to use; if unspecified, whatever is in the
         request, keyed at 'ActionID', is used with the output of `id_generator` being a fallback.
-        
+
         Asterisk's response is returned as a named tuple of the following form, or `None` if the
         request timed out:
-        
+
         - result: The processed response from Asterisk, nominally the same as `response`; see the
           specific `_Request` subclass for details in case it provides additional processing
         - response: The formatted, but unprocessed, response from Asterisk
@@ -498,10 +564,10 @@ class Manager:
         - time: The number of seconds, as a float, that the request took to be serviced
         - events: A dictionary containing related events if the request is synchronous or None otherwise
         - events_timeout: Whether the request timed out while waiting for events
-        
+
         For forward-compatibility reasons, elements of the tuple should be accessed by name, rather
         than by index.
-        
+
         Raises `ManagerError` if the manager is not connected.
 
         Raises `ManagerSocketError` if the socket is broken during transmission.
@@ -510,24 +576,38 @@ class Manager:
         """
         if not self.is_connected():
             raise ManagerError("Not connected to an Asterisk manager")
-            
-        (command, action_id) = request.build_request(None if action_id is None else str(action_id), self._get_host_action_id, **kwargs)
+
+        (command, action_id) = request.build_request(
+            None if action_id is None else str(action_id),
+            self._get_host_action_id,
+            **kwargs,
+        )
         events = self._add_outstanding_request(action_id, request)
         with self._connection_lock:
             self._connection.send_message(command)
-            
-        if request.aggregate and not request.synchronous: #Set up aggregate-event generation
+
+        if (
+            request.aggregate and not request.synchronous
+        ):  # Set up aggregate-event generation
             with self._event_aggregates_lock:
                 for aggregate_class in request.get_aggregate_classes():
-                    self._event_aggregates.append((time.time() + self._event_aggregates_timeout, aggregate_class(action_id)))
+                    self._event_aggregates.append(
+                        (
+                            time.time() + self._event_aggregates_timeout,
+                            aggregate_class(action_id),
+                        )
+                    )
                     if self._debug:
-                        (self._logger and self._logger.debug or warnings.warn)("Started building aggregate-event '%(event)s' for action-ID '%(action-id)s'" % {
-                         'event': _EVENT_REGISTRY_REV.get(aggregate_class),
-                         'action-id': action_id,
-                        })
+                        (self._logger and self._logger.debug or warnings.warn)(
+                            "Started building aggregate-event '%(event)s' for action-ID '%(action-id)s'"
+                            % {
+                                "event": _EVENT_REGISTRY_REV.get(aggregate_class),
+                                "action-id": action_id,
+                            }
+                        )
 
         start_time = time.time()
-        if request['Action'] == 'Originate':
+        if request["Action"] == "Originate":
             # timeout is in millisecs
             timeout = start_time + (request.timeout / 1000)
         else:
@@ -535,26 +615,36 @@ class Manager:
         response = processed_response = success = None
         events_timeout = False
         while time.time() < timeout:
-            if not response: #If blocking for event synchronisation, don't bother polling for the already-received response
+            if not response:  # If blocking for event synchronisation, don't bother polling for the already-received response
                 with self._connection_lock:
                     response = self._message_reader.get_response(action_id)
                 if response:
                     processed_response = request.process_response(response)
-                    success = hasattr(processed_response, 'success') and processed_response.success
+                    success = (
+                        hasattr(processed_response, "success")
+                        and processed_response.success
+                    )
                     if not request.synchronous or not success:
-                        break #No events to watch for
-            else: #Synchronous processing
-                if self._check_outstanding_request_complete(action_id): #Not waiting for any more events
+                        break  # No events to watch for
+            else:  # Synchronous processing
+                if self._check_outstanding_request_complete(
+                    action_id
+                ):  # Not waiting for any more events
                     break
             time.sleep(0.05)
-        else: #Timed out
+        else:  # Timed out
             if request.synchronous:
                 events_timeout = True
-                (self._logger and self._logger.warn or warnings.warn)("Timed out while collecting events for synchronised action-ID '%(action-id)s'" % {
-                 'action-id': action_id,
-                })
-                
-        self._serve_outstanding_request(action_id) #Get the ActionID out of circulation
+                (self._logger and self._logger.warn or warnings.warn)(
+                    "Timed out while collecting events for synchronised action-ID '%(action-id)s'"
+                    % {
+                        "action-id": action_id,
+                    }
+                )
+
+        self._serve_outstanding_request(
+            action_id
+        )  # Get the ActionID out of circulation
         if response:
             return _Response(
                 processed_response,
@@ -564,20 +654,23 @@ class Manager:
                 success,
                 time.time() - start_time,
                 events,
-                events_timeout
+                events_timeout,
             )
         else:
-            (self._logger and self._logger.warn or warnings.warn)("Timed out while waiting for response for action-ID '%(action-id)s'" % {
-             'action-id': action_id,
-            })
+            (self._logger and self._logger.warn or warnings.warn)(
+                "Timed out while waiting for response for action-ID '%(action-id)s'"
+                % {
+                    "action-id": action_id,
+                }
+            )
             return None
 
     def _add_outstanding_request(self, action_id, request):
         """
         Beings tracking the given `action_id` to synchronise communication with Asterisk.
-        
+
         If full event-synchronisation is requested, that's set up here, too.
-        
+
         The value returned is the events-map, if one was set up.
         """
         with self._connection_lock:
@@ -591,45 +684,51 @@ class Manager:
                     events[c] = events[_EVENT_REGISTRY_REV.get(c)] = []
                 for c in finalisers:
                     events[c] = events[_EVENT_REGISTRY_REV.get(c)] = None
-                    
+
                 self._outstanding_requests[action_id] = (events, set(finalisers))
                 return events
             else:
                 self._outstanding_requests[action_id] = None
                 return None
-                
+
     def _check_outstanding_request_complete(self, action_id):
         """
         Yields a boolean value that indicates whether the indicated request has been fully served,
         in terms of having received all expected requests if synchronised.
-        
+
         If not synchronised or if the request isn't tracked, the value returned is True.
         """
         with self._connection_lock:
             status = self._outstanding_requests.get(action_id)
-            if not status: #Undefined or not synchronous
+            if not status:  # Undefined or not synchronous
                 return True
-            return not status[1] #True if all finalisers have been received
-            
+            return not status[1]  # True if all finalisers have been received
+
     def _process_outstanding_request_event(self, event):
         """
         Checks the event against pending requests and adds it to the appropriate event-list, if one
         exists, updating pending finalisers as needed.
-        
+
         The value returned indicates whether the event was bound to an action.
         """
         with self._connection_lock:
             status = self._outstanding_requests.get(event.action_id)
-            if status: #It's being tracked
+            if status:  # It's being tracked
                 event_type = type(event)
-                
-                status[1].discard(event_type) #Mark it as received if it's a finaliser
-                
+
+                status[1].discard(event_type)  # Mark it as received if it's a finaliser
+
                 value = status[0].get(event_type)
-                if type(value) is list: #If it's part of a list-type, add it to the collection
-                    value.append(event) #No need to add it to both the named and class-type value, since they share the same list
-                else: #Set it as the relevant entry, for both the class-def and named keys
-                    status[0][event_type] = status[0][_EVENT_REGISTRY_REV.get(event_type)] = event
+                if (
+                    type(value) is list
+                ):  # If it's part of a list-type, add it to the collection
+                    value.append(
+                        event
+                    )  # No need to add it to both the named and class-type value, since they share the same list
+                else:  # Set it as the relevant entry, for both the class-def and named keys
+                    status[0][event_type] = status[0][
+                        _EVENT_REGISTRY_REV.get(event_type)
+                    ] = event
                 return True
         return False
 
@@ -644,12 +743,14 @@ class Manager:
                 del self._outstanding_requests[action_id]
             return served
 
+
 class _MessageTemplate:
     """
     An abstract base-class for all message-types, including aggregates.
     """
+
     __meta__ = abc.ABCMeta
-    
+
     def __eq__(self, o):
         """
         A convenience qualifier for decision-blocks to allow the message to be compared to strings for
@@ -658,71 +759,75 @@ class _MessageTemplate:
         if isinstance(o, str):
             return self.name == o
         return dict.__eq__(self, o)
-        
+
     @property
     def action_id(self):
         """
         Provides the action-ID associated with the message, if any.
         """
         raise NotImplementedError("Action-IDs must be implemented by subclasses")
-        
+
     @property
     def name(self):
         """
         Provides the name of the message.
         """
         raise NotImplementedError("Names must be implemented by subclasses")
-        
+
+
 class _Aggregate(_MessageTemplate, dict):
     """
     Provides, as a dictionary, access to all events that make up the aggregation, keyed by
     event-class. Repeatable event-types are exposed as lists, while others are direct references to
     the event itself.
     """
-    _name = None #The name of the aggregate-type
-    _action_id = None #The action-ID associated with the aggregate, if any
-    _valid = True #Indicates whether the aggregate's contents are consistent with Asterisk's protocol
-    _error_message = None #A string that explains why validation failed, if it failed
-    
-    _aggregation_members = () #A tuple containing all classes that can be members of this aggregation
-    _aggregation_finalisers = () #A tuplecontaining all class that must be received for the aggregation to be complete
-    _pending_finalisers = None #All finalisers yet to be received
-    
+
+    _name = None  # The name of the aggregate-type
+    _action_id = None  # The action-ID associated with the aggregate, if any
+    _valid = True  # Indicates whether the aggregate's contents are consistent with Asterisk's protocol
+    _error_message = None  # A string that explains why validation failed, if it failed
+
+    _aggregation_members = ()  # A tuple containing all classes that can be members of this aggregation
+    _aggregation_finalisers = ()  # A tuplecontaining all class that must be received for the aggregation to be complete
+    _pending_finalisers = None  # All finalisers yet to be received
+
     def __init__(self, action_id):
         """
         Associates the aggregate with an action-ID.
         """
         self._action_id = action_id
         self._pending_finalisers = set(self._aggregation_finalisers)
-        
+
         global _EVENT_REGISTRY_REV
         for c in self._aggregation_members:
             self[c] = self[_EVENT_REGISTRY_REV.get(c)] = []
         for c in self._aggregation_finalisers:
             self[c] = self[_EVENT_REGISTRY_REV.get(c)] = None
-            
+
     def _evaluate_action_id(self, event):
         """
         Indicates whether the aggregate's action-ID matches that of the event.
         """
         return self._action_id == event.action_id
-        
+
     def _aggregate(self, event):
         """
         Adds the `event` to this aggregate, if appropriate, inheriting properties as necessary.
-        
+
         The value returned indicates whether `event` was added.
         """
         if self._evaluate_action_id(event):
-            self[type(event)].append(event) #Lists are shared between class-object and string elements
+            self[type(event)].append(
+                event
+            )  # Lists are shared between class-object and string elements
             return True
         return False
-        
+
     def _finalise(self, event):
         """
         Finalises this aggregate, if appropriate, performing any additional checks as needed, based
         on the properties of the `event`.
-        
+
         The value returned indicates whether finalisation succeeded.
         """
         if self._evaluate_action_id(event):
@@ -731,30 +836,37 @@ class _Aggregate(_MessageTemplate, dict):
             self._pending_finalisers.discard(event_type)
             return len(self._pending_finalisers) == 0
         return False
-        
+
     def _check_list_items_count(self, event, count_header):
         """
         Most finalisers have a count-property, so check it to assert validity.
-        
+
         `count_header` identifies the header-item to check to validate the number of received
         entries.
         """
         event = event.process()[0]
         list_items_count = event.get(count_header)
         if list_items_count is not None:
-            items_count = sum(len(v) for (k, v) in self.items() if type(v) is list and isinstance(k, str))
+            items_count = sum(
+                len(v)
+                for (k, v) in self.items()
+                if type(v) is list and isinstance(k, str)
+            )
             self._valid = list_items_count == items_count
             if not self._valid:
-                self._error_message = "Expected %(event)i list-items; received %(count)i" % {
-                 'event': list_items_count,
-                 'count': items_count,
-                }
-                
+                self._error_message = (
+                    "Expected %(event)i list-items; received %(count)i"
+                    % {
+                        "event": list_items_count,
+                        "count": items_count,
+                    }
+                )
+
     def evaluate_event(self, event):
         """
         Folds the event into the aggregation, if it's associated with the same action-ID and is of a
         relevant type.
-        
+
         `True` is returned if the aggregate is finalised after this event, `False` if it was simply
         merged, or `None` if the aggregate was unrelated.
         """
@@ -765,35 +877,36 @@ class _Aggregate(_MessageTemplate, dict):
         elif event_type in self._aggregation_finalisers:
             return self._finalise(event)
         return None
-        
+
     @property
     def action_id(self):
         """
         Provides the action-ID associated with the message, if any.
         """
         return self._action_id
-        
+
     @property
     def name(self):
         """
         Provides the name of the event or response.
         """
         return self._name
-        
+
     @property
     def valid(self):
         """
         Indicates whether the aggregate is consistent with Asterisk's protocol.
         """
         return self._valid
-        
+
     @property
     def error_message(self):
         """
         If `valid` is `False`, this will offer a string explaining why validation failed.
         """
         return self._error_message
-        
+
+
 class _Message(_MessageTemplate, dict):
     """
     The common base-class for both replies and events, this is any structured response received
@@ -801,29 +914,32 @@ class _Message(_MessageTemplate, dict):
 
     All message headers are exposed as dictionary items on this object directly.
     """
-    data = None #The payload received from Asterisk
-    headers = None #A reference to this object, which is a dictionary with header responses from Asterisk
-    raw = None #The raw response received from Asterisk
-    
+
+    data = None  # The payload received from Asterisk
+    headers = None  # A reference to this object, which is a dictionary with header responses from Asterisk
+    raw = None  # The raw response received from Asterisk
+
     def __init__(self, response):
         """
         Parses the `response` received from Asterisk and assembles a structured event object
         suitable for processing by application logic.
         """
         self.data = []
-        self.headers = self #For simplicity's sake, the 'headers' property is a recursive reference to this object
+        self.headers = self  # For simplicity's sake, the 'headers' property is a recursive reference to this object
         self.raw = response
         self._parse(response)
 
-        #Apply some tests to see if Asterisk sent back a malformed response and try to make it
-        #salvagable. This typically only happens with specific events, so applications can deal
-        #with it more effectively than the processing core.
+        # Apply some tests to see if Asterisk sent back a malformed response and try to make it
+        # salvagable. This typically only happens with specific events, so applications can deal
+        # with it more effectively than the processing core.
         if KEY_EVENT not in self and KEY_RESPONSE not in self:
-            if KEY_ACTIONID in self: #If 'ActionID' is present, it's a response to an action.
+            if (
+                KEY_ACTIONID in self
+            ):  # If 'ActionID' is present, it's a response to an action.
                 self.headers[KEY_RESPONSE] = RESPONSE_GENERIC
-            else: #It's an unsolicited event
+            else:  # It's an unsolicited event
                 self.headers[KEY_EVENT] = EVENT_GENERIC
-                
+
     def _parse(self, response):
         """
         Parses the response from Asterisk.
@@ -832,10 +948,12 @@ class _Message(_MessageTemplate, dict):
         """
         while response:
             line = response[0]
-            if line.endswith(_EOL_FAKE) or not line.endswith(_EOL) or ':' not in line: #All lines from this point forth are data
+            if (
+                line.endswith(_EOL_FAKE) or not line.endswith(_EOL) or ":" not in line
+            ):  # All lines from this point forth are data
                 self.data.extend((entry.strip() for entry in response))
                 break
-            (key, value) = response.pop(0).split(':', 1)
+            (key, value) = response.pop(0).split(":", 1)
             self[key.strip()] = value.strip()
 
     @property
@@ -844,7 +962,7 @@ class _Message(_MessageTemplate, dict):
         Provides the action-ID associated with the message, if any.
         """
         return self.get(KEY_ACTIONID)
-        
+
     @property
     def name(self):
         """
@@ -852,11 +970,13 @@ class _Message(_MessageTemplate, dict):
         """
         return self.get(KEY_EVENT) or self.get(KEY_RESPONSE)
 
+
 class _Event(_Message):
     """
     The base-class of any event received from Asterisk, either unsolicited or as part of an extended
     response-chain.
     """
+
     def process(self):
         """
         Provides a tuple containing a copy of all headers as a dictionary and a copy of all response
@@ -864,47 +984,51 @@ class _Event(_Message):
         replacing the values of headers with Python types or making the data easier to work with.
         """
         return (self.copy(), self.data[:])
-        
+
+
 class _Request(dict):
     """
     Provides a generic container for assembling AMI requests, the basis of all actions.
-    
+
     Subclasses may override `__init__` and define any additional behaviours they may need, as well
     as override `process_response()` to specially format the data to be returned after a request
     has been served.
     """
-    aggregate = False #Only has an effect on certain types of requests; will result in an aggregate-event being generated after a list of independent events
-    synchronous = False #If True, requests will block until all response events have been collected; these events will appear in a `response` dictionary-attribute
-    timeout = 5 #The number of seconds to wait before considering this request timed out; may be a float
-    
-    _aggregates = () #A tuple containing all aggregate-types associated with this request
-    _synchronous_events_unique = () #A tuple containing all unique events associatable with this request
-    _synchronous_events_list = () #A tuple containing all list-type events associatable with this request
-    _synchronous_events_finalising = () #A tuple containing all events that must be received to consider this request complete
-    
+
+    aggregate = False  # Only has an effect on certain types of requests; will result in an aggregate-event being generated after a list of independent events
+    synchronous = False  # If True, requests will block until all response events have been collected; these events will appear in a `response` dictionary-attribute
+    timeout = 5  # The number of seconds to wait before considering this request timed out; may be a float
+
+    _aggregates = ()  # A tuple containing all aggregate-types associated with this request
+    _synchronous_events_unique = ()  # A tuple containing all unique events associatable with this request
+    _synchronous_events_list = ()  # A tuple containing all list-type events associatable with this request
+    _synchronous_events_finalising = ()  # A tuple containing all events that must be received to consider this request complete
+
     def __init__(self, action):
         """
         `action` is the type of action being requested of the Asterisk server.
         """
-        self['Action'] = action
-        
+        self["Action"] = action
+
     def build_request(self, action_id, id_generator, **kwargs):
         """
         Returns a string formatted for transmission to Asterisk to place a request and the action ID
         associated with the request.
-        
+
         `action_id` is the Asterisk ActionID to use, or None to use whatever is in the request, if
         anything, or the output of `id_generator` if not.
-        
+
         `id_generator` is a function that generates an Asterisk ActionID.
-        
+
         `**kwargs` is a dictionary of additional arguments that may be passed along with the request
         at submission time.
-        
+
         The 'Action' line is always first.
         """
         items = [(KEY_ACTION, self[KEY_ACTION])]
-        for (key, value) in [(k, v) for (k, v) in self.items() if k not in (KEY_ACTION, KEY_ACTIONID)] + list(kwargs.items()):
+        for key, value in [
+            (k, v) for (k, v) in self.items() if k not in (KEY_ACTION, KEY_ACTIONID)
+        ] + list(kwargs.items()):
             key = str(key)
             if type(value) in (tuple, list, set, frozenset):
                 for val in value:
@@ -912,60 +1036,76 @@ class _Request(dict):
             else:
                 items.append((key, str(value)))
 
-        #Resolve the ActionID using the precedence documented above: an explicit
-        #argument wins, then any value already set on the request, then a generated
-        #one. Fall back only when the argument is None, not merely falsy, and coerce
-        #to a string so it matches the string-keyed responses Asterisk sends back.
+        # Resolve the ActionID using the precedence documented above: an explicit
+        # argument wins, then any value already set on the request, then a generated
+        # one. Fall back only when the argument is None, not merely falsy, and coerce
+        # to a string so it matches the string-keyed responses Asterisk sends back.
         if action_id is None:
             action_id = self[KEY_ACTIONID] if KEY_ACTIONID in self else id_generator()
         action_id = str(action_id)
         items.append((KEY_ACTIONID, action_id))
-            
+
         return (
-         _EOL.join(['%(key)s: %(value)s' % {
-          'key': key,
-          'value': value,
-         } for (key, value) in items] + [_EOL]),
-         action_id,
+            _EOL.join(
+                [
+                    "%(key)s: %(value)s"
+                    % {
+                        "key": key,
+                        "value": value,
+                    }
+                    for (key, value) in items
+                ]
+                + [_EOL]
+            ),
+            action_id,
         )
 
     def process_response(self, response):
         """
         Provides an opportunity to parse, filter, or react to a response from Asterisk.
-        
+
         This implementation just passes the response back to the caller as received, adding a new
         'success' attribute on the response object with a boolean value.
         """
-        response.success = response.get('Response') in ('Success', 'Follows')
+        response.success = response.get("Response") in ("Success", "Follows")
         return response
-        
+
     def get_aggregate_classes(self):
         """
         Provides a tuple of all aggregate event-classes associated with this request.
         """
         return self._aggregates
-        
+
     def get_synchronous_classes(self):
         """
         Provides a triple of (unique, list, finalising) tuples of sychronous event-classes
         associated with this request.
         """
-        return (self._synchronous_events_unique, self._synchronous_events_list, self._synchronous_events_finalising)
-        
+        return (
+            self._synchronous_events_unique,
+            self._synchronous_events_list,
+            self._synchronous_events_finalising,
+        )
+
+
 class _MessageReader(threading.Thread):
-    event_queue = None #A queue containing unsolicited events received from Asterisk
-    response_queue = None #A queue containing orphaned or unparented responses from Asterisk
-    _alive = True #False when this thread has been killed
-    _manager = None #A reference to the manager instance that serves as the parent of this thread
-    _orphaned_response_timeout = None #The number of seconds to hold on to request-responses before considering them to be timed-out
-    _served_requests = None #A dictionary of responses from Asterisk, keyed by ActionID
-    _served_requests_lock = None #A means of preventing race conditions from affecting the served-request set
+    event_queue = None  # A queue containing unsolicited events received from Asterisk
+    response_queue = (
+        None  # A queue containing orphaned or unparented responses from Asterisk
+    )
+    _alive = True  # False when this thread has been killed
+    _manager = None  # A reference to the manager instance that serves as the parent of this thread
+    _orphaned_response_timeout = None  # The number of seconds to hold on to request-responses before considering them to be timed-out
+    _served_requests = (
+        None  # A dictionary of responses from Asterisk, keyed by ActionID
+    )
+    _served_requests_lock = None  # A means of preventing race conditions from affecting the served-request set
 
     def __init__(self, manager, orphaned_response_timeout):
         threading.Thread.__init__(self)
         self.daemon = True
-        self.name = 'pystrix-ami-message-reader'
-        
+        self.name = "pystrix-ami-message-reader"
+
         self._manager = manager
         self._orphaned_response_timeout = orphaned_response_timeout
 
@@ -973,7 +1113,7 @@ class _MessageReader(threading.Thread):
         self.response_queue = queue.Queue()
         self._served_requests = {}
         self._served_requests_lock = threading.Lock()
-        
+
     def _clean_orphaned_responses(self):
         """
         Ensures that old responses are moved to the orphaned queue, even though they should never
@@ -982,14 +1122,14 @@ class _MessageReader(threading.Thread):
         current_time = time.time()
         with self._served_requests_lock:
             expired_action_ids = []
-            for (action_id, (response, timeout)) in self._served_requests.items():
+            for action_id, (response, timeout) in self._served_requests.items():
                 if timeout <= current_time:
                     expired_action_ids.append(action_id)
-                    self.response_queue.put(response) #Move it to the queue
-                    
+                    self.response_queue.put(response)  # Move it to the queue
+
             for action_id in expired_action_ids:
                 del self._served_requests[action_id]
-                
+
     def kill(self):
         self._alive = False
 
@@ -1003,7 +1143,7 @@ class _MessageReader(threading.Thread):
                 del self._served_requests[action_id]
                 return response[0]
             return None
-            
+
     def run(self):
         """
         Continuously reads messages from the Asterisk server, placing them in the appropriate queue.
@@ -1013,50 +1153,65 @@ class _MessageReader(threading.Thread):
         global _EVENT_REGISTRY
         global KEY_ACTIONID
         socket = self._manager.get_connection()
-        
+
         while self._alive:
             try:
                 message = socket.read_message()
                 if not message:
                     continue
             except ManagerSocketError:
-                break #Nothing can be reported, but the socket died, so there's no point in running
+                break  # Nothing can be reported, but the socket died, so there's no point in running
             else:
                 action_id = message.get(KEY_ACTIONID)
                 if KEY_EVENT in message:
-                    #See if the event has a corresponding subclass and mutate it if it does
+                    # See if the event has a corresponding subclass and mutate it if it does
                     event_class = _EVENT_REGISTRY.get(message.name)
                     if event_class:
                         message.__class__ = event_class
                     else:
                         message.__class__ = _Event
                         if self._manager._debug:
-                            (self._manager._logger and self._manager._logger.warn or warnings.warn)("Unknown event received: " + repr(message))
-                            
+                            (
+                                self._manager._logger
+                                and self._manager._logger.warn
+                                or warnings.warn
+                            )("Unknown event received: " + repr(message))
+
                     self.event_queue.put(message)
                 elif action_id is not None:
                     self._clean_orphaned_responses()
                     with self._served_requests_lock:
                         if action_id not in self._served_requests:
-                            self._served_requests[action_id] = (message, time.time() + self._orphaned_response_timeout)
-                        else: #If there's already an associated response, treat this one as orphaned to avoid data-loss
+                            self._served_requests[action_id] = (
+                                message,
+                                time.time() + self._orphaned_response_timeout,
+                            )
+                        else:  # If there's already an associated response, treat this one as orphaned to avoid data-loss
                             self.response_queue.put(message)
-                else: #It's an orphaned response
+                else:  # It's an orphaned response
                     self.response_queue.put(message)
-                    
+
+
 class _SynchronisedSocket:
     """
     Provides a threadsafe conduit for communication with an Asterisk manager interface.
     """
-    _asterisk_name = '<unknown>' #The name of the Asterisk server to which the socket is connected
-    _asterisk_version = '<unknown>' # The version of the Asterisk server to which the socket is connected
-    _connected = False #True while a connection is active
-    _socket = None #The socket used to communicate with the Asterisk server
-    _socket_file = None #The socket exposed as a file-like object
-    _socket_read_lock = None #A lock used to prevent race conditions from affecting the Asterisk link
-    _socket_write_lock = None #A lock used to prevent race conditions from affecting the Asterisk link
-    _timeout = None #The number of seconds to wait before considering communications with the Asterisk server timed out
-    
+
+    _asterisk_name = (
+        "<unknown>"  # The name of the Asterisk server to which the socket is connected
+    )
+    _asterisk_version = "<unknown>"  # The version of the Asterisk server to which the socket is connected
+    _connected = False  # True while a connection is active
+    _socket = None  # The socket used to communicate with the Asterisk server
+    _socket_file = None  # The socket exposed as a file-like object
+    _socket_read_lock = (
+        None  # A lock used to prevent race conditions from affecting the Asterisk link
+    )
+    _socket_write_lock = (
+        None  # A lock used to prevent race conditions from affecting the Asterisk link
+    )
+    _timeout = None  # The number of seconds to wait before considering communications with the Asterisk server timed out
+
     def __init__(self, host, port=5038, timeout=5):
         """
         Establishes a connection to the specified Asterisk manager, setting session variables as
@@ -1064,20 +1219,20 @@ class _SynchronisedSocket:
 
         `timeout` is the number of seconds to wait before considering the Asterisk server
         unresponsive.
-        
+
         If the connection fails, `ManagerSocketError` is raised.
         """
         self._timeout = timeout
         self._connect(host, port)
         self._socket_read_lock = threading.Lock()
         self._socket_write_lock = threading.Lock()
-        
+
     def __del__(self):
         """
         Ensure the resources are freed.
         """
         self.close()
-        
+
     def close(self):
         """
         Release resources associated with this connection.
@@ -1087,7 +1242,7 @@ class _SynchronisedSocket:
             return
         with self._socket_write_lock:
             self._close()
-            
+
     def _close(self):
         """
         Performs the actual closing; needed to avoid a deadlock.
@@ -1097,14 +1252,14 @@ class _SynchronisedSocket:
             try:
                 closable.close()
             except Exception:
-                pass #Can't do anything about it
-                
+                pass  # Can't do anything about it
+
     def get_asterisk_info(self):
         """
         Provides the name and version of Asterisk as a tuple of strings.
         """
         return (self._asterisk_name, self._asterisk_version)
-        
+
     def is_connected(self):
         """
         Indicates whether the socket is connected.
@@ -1118,48 +1273,57 @@ class _SynchronisedSocket:
 
         The message read is returned as a `_Message` after being parsed. Or `None` if a timeout
         occurred while waiting for a full message.
-        
+
         `ManagerSocketError` is raised if the connection is broken.
         """
         if not self.is_connected():
             raise ManagerSocketError("Not connected to Asterisk server")
-            
-        #Bring some often-referenced values into the local namespace
+
+        # Bring some often-referenced values into the local namespace
         global _EOC
         global _EOC_INDICATOR
         global _EOL
-        
-        wait_for_marker = False #When true, the special string '--END COMMAND--' is used to end a message, rather than a CRLF
-        response_lines = [] #Lines collected from Asterisk
-        while True: #Keep reading lines until a full message has been collected
+
+        wait_for_marker = False  # When true, the special string '--END COMMAND--' is used to end a message, rather than a CRLF
+        response_lines = []  # Lines collected from Asterisk
+        while True:  # Keep reading lines until a full message has been collected
             line = None
             with self._socket_read_lock:
                 try:
-                    line = generic_transforms.bytes_to_string(self._socket_file.readline())
+                    line = generic_transforms.bytes_to_string(
+                        self._socket_file.readline()
+                    )
                 except socket.timeout:
                     return None
                 except socket.error as e:
                     self._close()
-                    raise ManagerSocketError("Connection to Asterisk manager broken while reading data: %(error)s" % {
-                     'error': _format_socket_error(e),
-                    })
+                    raise ManagerSocketError(
+                        "Connection to Asterisk manager broken while reading data: %(error)s"
+                        % {
+                            "error": _format_socket_error(e),
+                        }
+                    )
                 except AttributeError:
-                    raise ManagerSocketError("Local socket no longer defined, caused by system shutdown and blocking I/O")
+                    raise ManagerSocketError(
+                        "Local socket no longer defined, caused by system shutdown and blocking I/O"
+                    )
 
             if line == _EOL and not wait_for_marker:
-                if response_lines: #A full response has been collected
+                if response_lines:  # A full response has been collected
                     return _Message(response_lines)
-                continue #Asterisk is allowed to send empty lines before and after real data, so ignore them
+                continue  # Asterisk is allowed to send empty lines before and after real data, so ignore them
 
-            #Test to see if this line is related to the requirements for an explicit end to the message
+            # Test to see if this line is related to the requirements for an explicit end to the message
             if wait_for_marker:
-                if line.startswith(_EOC): #The message is complete
+                if line.startswith(_EOC):  # The message is complete
                     return _Message(response_lines)
-            elif _EOC_INDICATOR.match(line): #Data that may contain the _EOL pattern is now legal
+            elif _EOC_INDICATOR.match(
+                line
+            ):  # Data that may contain the _EOL pattern is now legal
                 wait_for_marker = True
-                
-            response_lines.append(line) #Add the line to the response
-            
+
+            response_lines.append(line)  # Add the line to the response
+
     def send_message(self, message):
         """
         Locks the socket and writes the entire `message` into the stream.
@@ -1168,16 +1332,19 @@ class _SynchronisedSocket:
         """
         if not self.is_connected():
             raise ManagerSocketError("Not connected to Asterisk server")
-            
+
         with self._socket_write_lock:
             try:
                 self._socket.sendall(generic_transforms.string_to_bytes(message))
             except socket.error as e:
                 self._close()
-                raise ManagerSocketError("Connection to Asterisk manager broken while writing data: %(error)s" % {
-                 'error': _format_socket_error(e),
-                })
-                
+                raise ManagerSocketError(
+                    "Connection to Asterisk manager broken while writing data: %(error)s"
+                    % {
+                        "error": _format_socket_error(e),
+                    }
+                )
+
     def _connect(self, host, port):
         """
         Establishes a connection to the specified Asterisk manager, then dissects its greeting.
@@ -1194,36 +1361,46 @@ class _SynchronisedSocket:
             self._socket_file = self._socket.makefile(mode="rb")
         except socket.error as e:
             self._socket.close()
-            raise ManagerSocketError("Connection to Asterisk manager could not be established: %(error)s" % {
-             'error': _format_socket_error(e),
-            })
+            raise ManagerSocketError(
+                "Connection to Asterisk manager could not be established: %(error)s"
+                % {
+                    "error": _format_socket_error(e),
+                }
+            )
         self._connected = True
 
-        #Pop the greeting off the head of the pipe and set the version information
+        # Pop the greeting off the head of the pipe and set the version information
         try:
             line = generic_transforms.bytes_to_string(self._socket_file.readline())
         except socket.error as e:
             self._socket.close()
-            raise ManagerSocketError("Connection to Asterisk manager broken while reading greeting: %(error)s" % {
-             'error': _format_socket_error(e),
-            })
+            raise ManagerSocketError(
+                "Connection to Asterisk manager broken while reading greeting: %(error)s"
+                % {
+                    "error": _format_socket_error(e),
+                }
+            )
         else:
-            if '/' in line:
-                (self._asterisk_name, self._asterisk_version) = (token.strip() for token in line.split('/', 1))
-                
-                
-#Exceptions
+            if "/" in line:
+                (self._asterisk_name, self._asterisk_version) = (
+                    token.strip() for token in line.split("/", 1)
+                )
+
+
+# Exceptions
 ###############################################################################
 class Error(Exception):
     """
     The base exception from which all errors native to this module inherit.
     """
-    
+
+
 class ManagerError(Error):
     """
     Represents a generic error involving the Asterisk manager.
     """
-    
+
+
 class ManagerSocketError(Error):
     """
     Represents a generic error involving the Asterisk connection.

--- a/pystrix/ami/app_confbridge.py
+++ b/pystrix/ami/app_confbridge.py
@@ -6,7 +6,7 @@ Provides classes meant to be fed to a `Manager` instance's `send_action()` funct
 
 Specifically, this module provides implementations for features specific to the ConfBridge
 application.
- 
+
 Legal
 -----
 
@@ -34,38 +34,43 @@ Authors:
 The requests and events implemented by this module follow the definitions provided by
 https://wiki.asterisk.org/
 """
-from pystrix.ami.ami import (_Request)
-from pystrix.ami import core_events
-from pystrix.ami import app_confbridge_events
+
+from pystrix.ami import app_confbridge_events, core_events
+from pystrix.ami.ami import _Request
+
 
 class ConfbridgeKick(_Request):
     """
     Kicks a participant from a ConfBridge room.
     """
+
     def __init__(self, conference, channel):
         """
         `channel` is the channel to be kicked from `conference`.
         """
-        _Request.__init__(self, 'ConfbridgeKick')
-        self['Conference'] = conference
-        self['Channel'] = channel
-        
+        _Request.__init__(self, "ConfbridgeKick")
+        self["Conference"] = conference
+        self["Channel"] = channel
+
+
 class ConfbridgeList(_Request):
     """
     Lists all participants in a ConfBridge room.
 
     A series of 'ConfbridgeList' events follow, with one 'ConfbridgeListComplete' event at the end.
     """
+
     _aggregates = (app_confbridge_events.ConfbridgeList_Aggregate,)
     _synchronous_events_list = (app_confbridge_events.ConfbridgeList,)
     _synchronous_events_finalising = (app_confbridge_events.ConfbridgeListComplete,)
-    
+
     def __init__(self, conference):
         """
         `conference` is the identifier of the bridge.
         """
-        _Request.__init__(self, 'ConfbridgeList')
-        self['Conference'] = conference
+        _Request.__init__(self, "ConfbridgeList")
+        self["Conference"] = conference
+
 
 class ConfbridgeListRooms(_Request):
     """
@@ -74,109 +79,127 @@ class ConfbridgeListRooms(_Request):
     A series of 'ConfbridgeListRooms' events follow, with one 'ConfbridgeListRoomsComplete' event at
     the end.
     """
+
     _aggregates = (app_confbridge_events.ConfbridgeListRooms_Aggregate,)
     _synchronous_events_list = (app_confbridge_events.ConfbridgeListRooms,)
-    _synchronous_events_finalising = (app_confbridge_events.ConfbridgeListRoomsComplete,)
-    
+    _synchronous_events_finalising = (
+        app_confbridge_events.ConfbridgeListRoomsComplete,
+    )
+
     def __init__(self):
-        _Request.__init__(self, 'ConfbridgeListRooms')
+        _Request.__init__(self, "ConfbridgeListRooms")
+
 
 class ConfbridgeLock(_Request):
     """
     Locks a ConfBridge room, disallowing access to non-administrators.
     """
+
     def __init__(self, conference):
         """
         `conference` is the identifier of the bridge.
         """
-        _Request.__init__(self, 'ConfbridgeLock')
-        self['Conference'] = conference
+        _Request.__init__(self, "ConfbridgeLock")
+        self["Conference"] = conference
+
 
 class ConfbridgeUnlock(_Request):
     """
     Unlocks a ConfBridge room, allowing access to non-administrators.
     """
+
     def __init__(self, conference):
         """
         `conference` is the identifier of the bridge.
         """
-        _Request.__init__(self, 'ConfbridgeUnlock')
-        self['Conference'] = conference
+        _Request.__init__(self, "ConfbridgeUnlock")
+        self["Conference"] = conference
+
 
 class ConfbridgeMoHOn(_Request):
     """
     Forces MoH to a participant in a ConfBridge room.
-    
+
     This action does not mute audio coming from the participant.
-    
+
     Depends on <path>.
     """
+
     def __init__(self, conference, channel):
         """
         `channel` is the channel to which MoH should be started in `conference`.
         """
-        _Request.__init__(self, 'ConfbridgeMoHOn')
-        self['Conference'] = conference
-        self['Channel'] = channel
+        _Request.__init__(self, "ConfbridgeMoHOn")
+        self["Conference"] = conference
+        self["Channel"] = channel
+
 
 class ConfbridgeMoHOff(_Request):
     """
     Stops forcing MoH to a participant in a ConfBridge room.
-    
+
     This action does not unmute audio coming from the participant.
-    
+
     Depends on <path>.
     """
+
     def __init__(self, conference, channel):
         """
         `channel` is the channel to which MoH should be stopped in `conference`.
         """
-        _Request.__init__(self, 'ConfbridgeMoHOff')
-        self['Conference'] = conference
-        self['Channel'] = channel
+        _Request.__init__(self, "ConfbridgeMoHOff")
+        self["Conference"] = conference
+        self["Channel"] = channel
+
 
 class ConfbridgeMute(_Request):
     """
     Mutes a participant in a ConfBridge room.
     """
+
     def __init__(self, conference, channel):
         """
         `channel` is the channel to be muted in `conference`.
         """
-        _Request.__init__(self, 'ConfbridgeMute')
-        self['Conference'] = conference
-        self['Channel'] = channel
+        _Request.__init__(self, "ConfbridgeMute")
+        self["Conference"] = conference
+        self["Channel"] = channel
+
 
 class ConfbridgeUnmute(_Request):
     """
     Unmutes a participant in a ConfBridge room.
     """
+
     def __init__(self, conference, channel):
         """
         `channel` is the channel to be unmuted in `conference`.
         """
-        _Request.__init__(self, 'ConfbridgeUnmute')
-        self['Conference'] = conference
-        self['Channel'] = channel
+        _Request.__init__(self, "ConfbridgeUnmute")
+        self["Conference"] = conference
+        self["Channel"] = channel
+
 
 class ConfbridgePlayFile(_Request):
     """
     Plays a file to individuals or an entire conference.
-    
+
     Note: This implementation is built upon the not-yet-accepted patch under
     https://issues.asterisk.org/jira/browse/ASTERISK-19571
     """
+
     def __init__(self, file, conference, channel=None):
         """
         `file`, resolved like other Asterisk media, is played to `conference`
         or, if specified, a specific `channel` therein.
         """
-        _Request.__init__(self, 'ConfbridgePlayFile')
-        self['Conference'] = conference
+        _Request.__init__(self, "ConfbridgePlayFile")
+        self["Conference"] = conference
         if channel:
-            self['Channel'] = channel
-        self['File'] = file
-        
+            self["Channel"] = channel
+        self["File"] = file
+
+
 class ConfbridgeStartRecord(_Request):
     """
     Starts recording a ConfBridge conference.
@@ -186,17 +209,19 @@ class ConfbridgeStartRecord(_Request):
     Asterisk-generated identification data that can be discarded and "?" is the room ID. The
     'Variable' key must be "MIXMONITOR_FILENAME", with the 'Value' key holding the file's path.
     """
+
     _synchronous_events_finalising = (core_events.VarSet,)
-    
+
     def __init__(self, conference, filename=None):
         """
         `conference` is the room to be recorded, and `filename`, optional, is the path,
         Asterisk-resolved or absolute, of the file to write.
         """
-        _Request.__init__(self, 'ConfbridgeStartRecord')
-        self['Conference'] = conference
+        _Request.__init__(self, "ConfbridgeStartRecord")
+        self["Conference"] = conference
         if filename:
-            self['RecordFile'] = filename
+            self["RecordFile"] = filename
+
 
 class ConfbridgeStopRecord(_Request):
     """
@@ -206,24 +231,26 @@ class ConfbridgeStopRecord(_Request):
     it, match its 'Channel' key against "ConfBridgeRecorder/conf-?-...", where "..." is
     Asterisk-generated identification data that can be discarded and "?" is the room ID.
     """
+
     _synchronous_events_finalising = (core_events.Hangup,)
-    
+
     def __init__(self, conference):
         """
         `conference` is the room being recorded.
         """
-        _Request.__init__(self, 'ConfbridgeStopRecord')
-        self['Conference'] = conference
+        _Request.__init__(self, "ConfbridgeStopRecord")
+        self["Conference"] = conference
+
 
 class ConfbridgeSetSingleVideoSrc(_Request):
     """
     Sets the video source for the conference to a single channel's stream.
     """
+
     def __init__(self, conference, channel):
         """
         `channel` is the video source in `conference`.
         """
-        _Request.__init__(self, 'ConfbridgeSetSingleVideoSource')
-        self['Conference'] = conference
-        self['Channel'] = channel
-
+        _Request.__init__(self, "ConfbridgeSetSingleVideoSource")
+        self["Conference"] = conference
+        self["Channel"] = channel

--- a/pystrix/ami/app_confbridge_events.py
+++ b/pystrix/ami/app_confbridge_events.py
@@ -32,22 +32,25 @@ Authors:
 The events implemented by this module follow the definitions provided by
 http://www.asteriskdocs.org/ and https://wiki.asterisk.org/
 """
-from pystrix.ami.ami import (_Aggregate, _Event)
+
 from pystrix.ami import generic_transforms
-    
+from pystrix.ami.ami import _Aggregate, _Event
+
+
 class ConfbridgeEnd(_Event):
     """
     Indicates that a ConfBridge has ended.
-    
+
     - 'Conference' : The room's identifier
     """
-    
+
+
 class ConfbridgeJoin(_Event):
     """
     Indicates that a participant has joined a ConfBridge room.
-    
+
     `NameRecordingPath` blocks on <path>
-    
+
     - 'CallerIDname' (optional) : The name, on supporting channels, of the participant
     - 'CallerIDnum' : The (often) numeric address of the participant
     - 'Channel' : The channel that joined
@@ -56,21 +59,23 @@ class ConfbridgeJoin(_Event):
     - 'Uniqueid' : An Asterisk unique value
     """
 
+
 class ConfbridgeLeave(_Event):
     """
     Indicates that a participant has left a ConfBridge room.
-    
+
     - 'CallerIDname' (optional) : The name, on supporting channels, of the participant
     - 'CallerIDnum' : The (often) numeric address of the participant
     - 'Channel' : The channel that left
     - 'Conference' : The identifier of the room that was left
     - 'Uniqueid' : An Asterisk unique value
     """
-    
+
+
 class ConfbridgeList(_Event):
     """
     Describes a participant in a ConfBridge room.
-    
+
     - 'Admin' : 'Yes' or 'No'
     - 'CallerIDNum' : The (often) numeric address of the participant
     - 'CallerIDName' (optional) : The name of the participant on supporting channels
@@ -79,137 +84,164 @@ class ConfbridgeList(_Event):
     - 'MarkedUser' : 'Yes' or 'No'
     - 'NameRecordingPath' (optional) : The path at which the user's name-recording is kept
     """
+
     def process(self):
         """
         Translates the 'Admin' and 'MarkedUser' headers' values into bools.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_bool(headers, ('Admin', 'MarkedUser',), truth_value='Yes')
-            
+
+        generic_transforms.to_bool(
+            headers,
+            (
+                "Admin",
+                "MarkedUser",
+            ),
+            truth_value="Yes",
+        )
+
         return (headers, data)
+
 
 class ConfbridgeListComplete(_Event):
     """
     Indicates that all participants in a ConfBridge room have been enumerated.
-    
+
     - 'ListItems' : The number of items returned prior to this event
     """
+
     def process(self):
         """
         Translates the 'ListItems' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_int(headers, ('ListItems',), -1)
-        
+
+        generic_transforms.to_int(headers, ("ListItems",), -1)
+
         return (headers, data)
-        
+
+
 class ConfbridgeListRooms(_Event):
     """
     Describes a ConfBridge room.
-    
+
     And, yes, it's plural in Asterisk, too.
-    
+
     - 'Conference' : The room's identifier
     - 'Locked' : 'Yes' or 'No'
     - 'Marked' : The number of marked users
     - 'Parties' : The number of participants
     """
+
     def process(self):
         """
         Translates the 'Marked' and 'Parties' headers' values into ints, or -1 on failure.
-        
+
         Translates the 'Locked' header's value into a bool.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_bool(headers, ('Locked',), truth_value='Yes')
-        generic_transforms.to_int(headers, ('Marked', 'Parties',), -1)
-        
+
+        generic_transforms.to_bool(headers, ("Locked",), truth_value="Yes")
+        generic_transforms.to_int(
+            headers,
+            (
+                "Marked",
+                "Parties",
+            ),
+            -1,
+        )
+
         return (headers, data)
+
 
 class ConfbridgeListRoomsComplete(_Event):
     """
     Indicates that all ConfBridge rooms have been enumerated.
-    
+
     - 'ListItems' : The number of items returned prior to this event
     """
+
     def process(self):
         """
         Translates the 'ListItems' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_int(headers, ('ListItems',), -1)
-        
+
+        generic_transforms.to_int(headers, ("ListItems",), -1)
+
         return (headers, data)
-        
+
+
 class ConfbridgeStart(_Event):
     """
     Indicates that a ConfBridge has started.
-    
+
     - 'Conference' : The room's identifier
     """
+
 
 class ConfbridgeTalking(_Event):
     """
     Indicates that a participant has started or stopped talking.
-    
+
     - 'Channel' : The Asterisk channel in use by the participant
     - 'Conference' : The room's identifier
     - 'TalkingStatus' : 'on' or 'off'
     - 'Uniqueid' : An Asterisk unique value
     """
+
     def process(self):
         """
         Translates the 'TalkingStatus' header's value into a bool.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_bool(headers, ('TalkingStatus',), truth_value='on')
-        
+
+        generic_transforms.to_bool(headers, ("TalkingStatus",), truth_value="on")
+
         return (headers, data)
-        
-        
-#List-aggregation events
+
+
+# List-aggregation events
 ####################################################################################################
-#These define non-Asterisk-native event-types that collect multiple events (cases where multiple
-#events are generated in response to a single action) and emit the bundle as a single message.
+# These define non-Asterisk-native event-types that collect multiple events (cases where multiple
+# events are generated in response to a single action) and emit the bundle as a single message.
+
 
 class ConfbridgeList_Aggregate(_Aggregate):
     """
     Emitted after all conference participants have been received in response to a ConfbridgeList
     request.
-    
+
     Its members consist of ConfbridgeList events.
-    
+
     It is finalised by ConfbridgeListComplete.
     """
+
     _name = "ConfbridgeList_Aggregate"
-    
+
     _aggregation_members = (ConfbridgeList,)
     _aggregation_finalisers = (ConfbridgeListComplete,)
-    
+
     def _finalise(self, event):
-        self._check_list_items_count(event, 'ListItems')
+        self._check_list_items_count(event, "ListItems")
         return _Aggregate._finalise(self, event)
-        
+
+
 class ConfbridgeListRooms_Aggregate(_Aggregate):
     """
     Emitted after all conference rooms have been received in response to a ConfbridgeListRooms
     request.
-    
+
     Its members consist of ConfbridgeListRooms events.
-    
+
     It is finalised by ConfbridgeListRoomsComplete.
     """
+
     _name = "ConfbridgeListRooms_Aggregate"
-    
+
     _aggregation_members = (ConfbridgeListRooms,)
     _aggregation_finalisers = (ConfbridgeListRoomsComplete,)
-    
+
     def _finalise(self, event):
-        self._check_list_items_count(event, 'ListItems')
+        self._check_list_items_count(event, "ListItems")
         return _Aggregate._finalise(self, event)
-        

--- a/pystrix/ami/app_meetme.py
+++ b/pystrix/ami/app_meetme.py
@@ -34,8 +34,10 @@ Authors:
 The requests and events implemented by this module follow the definitions provided by
 http://www.asteriskdocs.org/ and https://wiki.asterisk.org/
 """
-from pystrix.ami.ami import (_Request)
+
 from pystrix.ami import app_meetme_events
+from pystrix.ami.ami import _Request
+
 
 class MeetmeList(_Request):
     """
@@ -46,18 +48,20 @@ class MeetmeList(_Request):
     Note that if no conferences are active, the response will indicate that it was not successful,
     per https://issues.asterisk.org/jira/browse/ASTERISK-16812
     """
+
     _aggregates = (app_meetme_events.MeetmeList_Aggregate,)
     _synchronous_events_list = (app_meetme_events.MeetmeList,)
     _synchronous_events_finalising = (app_meetme_events.MeetmeListComplete,)
-    
+
     def __init__(self, conference=None):
         """
         `conference` is the optional identifier of the bridge.
         """
-        _Request.__init__(self, 'MeetmeList')
+        _Request.__init__(self, "MeetmeList")
         if conference is not None:
-            self['Conference'] = conference
-            
+            self["Conference"] = conference
+
+
 class MeetmeListRooms(_Request):
     """
     Lists all conferences.
@@ -65,42 +69,46 @@ class MeetmeListRooms(_Request):
     A series of 'MeetmeListRooms' events follow, with one 'MeetmeListRoomsComplete' event at the
     end.
     """
+
     _aggregates = (app_meetme_events.MeetmeListRooms_Aggregate,)
     _synchronous_events_list = (app_meetme_events.MeetmeListRooms,)
     _synchronous_events_finalising = (app_meetme_events.MeetmeListRoomsComplete,)
-    
+
     def __init__(self):
-        _Request.__init__(self, 'MeetmeListRooms')
-        
+        _Request.__init__(self, "MeetmeListRooms")
+
+
 class MeetmeMute(_Request):
     """
     Mutes a participant in a Meetme bridge.
-    
+
     Requires call
     """
+
     def __init__(self, meetme, usernum):
         """
         `meetme` is the identifier of the bridge and `usernum` is the participant ID of the user to
         be muted, which is associated with a channel by the 'MeetmeJoin' event. If successful, this
         request will trigger a 'MeetmeMute' event.
         """
-        _Request.__init__(self, 'MeetmeMute')
-        self['Meetme'] = meetme
-        self['Usernum'] = usernum
+        _Request.__init__(self, "MeetmeMute")
+        self["Meetme"] = meetme
+        self["Usernum"] = usernum
+
 
 class MeetmeUnmute(_Request):
     """
     Unmutes a participant in a Meetme bridge.
-    
+
     Requires call
     """
+
     def __init__(self, meetme, usernum):
         """
         `meetme` is the identifier of the bridge and `usernum` is the participant ID of the user to
         be unmuted, which is associated with a channel by the 'MeetmeJoin' event. If successful,
         this request will trigger a 'MeetmeMute' event.
         """
-        _Request.__init__(self, 'MeetmeUnmute')
-        self['Meetme'] = meetme
-        self['Usernum'] = usernum
-        
+        _Request.__init__(self, "MeetmeUnmute")
+        self["Meetme"] = meetme
+        self["Usernum"] = usernum

--- a/pystrix/ami/app_meetme_events.py
+++ b/pystrix/ami/app_meetme_events.py
@@ -31,23 +31,26 @@ Authors:
 The events implemented by this module follow the definitions provided by
 http://www.asteriskdocs.org/ and https://wiki.asterisk.org/
 """
-from pystrix.ami.ami import (_Aggregate, _Event)
+
 from pystrix.ami import generic_transforms
+from pystrix.ami.ami import _Aggregate, _Event
+
 
 class MeetmeJoin(_Event):
     """
     Indicates that a user has joined a Meetme bridge.
-    
+
     - 'Channel' : The channel that was bridged
     - 'Meetme' : The ID of the Meetme bridge, typically a number formatted as a string
     - 'Uniqueid' : An Asterisk unique value
     - 'Usernum' : The bridge-specific participant ID assigned to the channel
     """
 
+
 class MeetmeList(_Event):
     """
     Describes a participant in a Meetme room.
-    
+
     - 'Admin' : 'Yes' or 'No'
     - 'CallerIDNum' : The (often) numeric address of the participant
     - 'CallerIDName' (optional) : The name of the participant on supporting channels
@@ -61,51 +64,62 @@ class MeetmeList(_Event):
     - 'Talking' : 'Yes', 'No', or 'Not monitored'
     - 'UserNumber' : The ID of the participant in the conference
     """
+
     def process(self):
         """
         Translates the 'Admin' and 'MarkedUser' headers' values into bools.
-        
+
         Translates the 'Talking' header's value into a bool, or `None` if not monitored.
-        
+
         Translates the 'UserNumber' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        
-        talking = headers.get('Talking')
-        if talking == 'Yes':
-            headers['Talking'] = True
-        elif talking == 'No':
-            headers['Talking'] = False
+
+        talking = headers.get("Talking")
+        if talking == "Yes":
+            headers["Talking"] = True
+        elif talking == "No":
+            headers["Talking"] = False
         else:
-            headers['Talking'] = None
-        
-        generic_transforms.to_bool(headers, ('Admin', 'MarkedUser',), truth_value='Yes')
-        generic_transforms.to_int(headers, ('UserNumber',), -1)
-            
+            headers["Talking"] = None
+
+        generic_transforms.to_bool(
+            headers,
+            (
+                "Admin",
+                "MarkedUser",
+            ),
+            truth_value="Yes",
+        )
+        generic_transforms.to_int(headers, ("UserNumber",), -1)
+
         return (headers, data)
+
 
 class MeetmeListComplete(_Event):
     """
     Indicates that all participants in a Meetme query have been enumerated.
-    
+
     - 'ListItems' : The number of items returned prior to this event
     """
+
     def process(self):
         """
         Translates the 'ListItems' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_int(headers, ('ListItems',), -1)
-        
+
+        generic_transforms.to_int(headers, ("ListItems",), -1)
+
         return (headers, data)
+
 
 class MeetmeListRooms(_Event):
     """
     Describes a Meetme room.
-    
+
     And, yes, it's plural in Asterisk, too.
-    
+
     - 'Activity' : The duration of the conference
     - 'Conference' : The room's identifier
     - 'Creation' : 'Dynamic' or 'Static'
@@ -113,92 +127,100 @@ class MeetmeListRooms(_Event):
     - 'Marked' : The number of marked users, but not as an integer: 'N/A' or %.4d
     - 'Parties' : The number of participants
     """
+
     def process(self):
         """
         Translates the 'Parties' header's value into an int, or -1 on failure.
-        
+
         Translates the 'Locked' header's value into a bool.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_bool(headers, ('Locked',), truth_value='Yes')
-        generic_transforms.to_int(headers, ('Parties',), -1)
-        
+
+        generic_transforms.to_bool(headers, ("Locked",), truth_value="Yes")
+        generic_transforms.to_int(headers, ("Parties",), -1)
+
         return (headers, data)
+
 
 class MeetmeListRoomsComplete(_Event):
     """
     Indicates that all Meetme rooms have been enumerated.
-    
+
     - 'ListItems' : The number of items returned prior to this event
     """
+
     def process(self):
         """
         Translates the 'ListItems' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_int(headers, ('ListItems',), -1)
-        
+
+        generic_transforms.to_int(headers, ("ListItems",), -1)
+
         return (headers, data)
+
 
 class MeetmeMute(_Event):
     """
     Indicates that a user has been muted in a Meetme bridge.
-    
+
     - 'Channel' : The channel that was muted
     - 'Meetme' : The ID of the Meetme bridge, typically a number formatted as a string
     - 'Status' : 'on' or 'off', depending on whether the user was muted or unmuted
     - 'Uniqueid' : An Asterisk unique value
     - 'Usernum' : The participant ID of the user that was affected
     """
+
     def process(self):
         """
         Translates the 'Status' header's value into a bool.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_bool(headers, ('Status',), truth_value='on')
-        
+
+        generic_transforms.to_bool(headers, ("Status",), truth_value="on")
+
         return (headers, data)
-        
-        
-#List-aggregation events
+
+
+# List-aggregation events
 ####################################################################################################
-#These define non-Asterisk-native event-types that collect multiple events (cases where multiple
-#events are generated in response to a single action) and emit the bundle as a single message.
+# These define non-Asterisk-native event-types that collect multiple events (cases where multiple
+# events are generated in response to a single action) and emit the bundle as a single message.
+
 
 class MeetmeList_Aggregate(_Aggregate):
     """
     Emitted after all participants have been received in response to a MeetmeList request.
-    
+
     Its members consist of MeetmeList events.
-    
+
     It is finalised by MeetmeListComplete.
     """
+
     _name = "MeetmeList_Aggregate"
-    
+
     _aggregation_members = (MeetmeList,)
     _aggregation_finalisers = (MeetmeListComplete,)
-    
+
     def _finalise(self, event):
-        self._check_list_items_count(event, 'ListItems')
+        self._check_list_items_count(event, "ListItems")
         return _Aggregate._finalise(self, event)
-        
+
+
 class MeetmeListRooms_Aggregate(_Aggregate):
     """
     Emitted after all participants have been received in response to a MeetmeListRooms request.
-    
+
     Its members consist of MeetmeListRooms events.
-    
+
     It is finalised by MeetmeListRoomsComplete.
     """
+
     _name = "MeetmeListRooms_Aggregate"
-    
+
     _aggregation_members = (MeetmeListRooms,)
     _aggregation_finalisers = (MeetmeListRoomsComplete,)
-    
+
     def _finalise(self, event):
-        self._check_list_items_count(event, 'ListItems')
+        self._check_list_items_count(event, "ListItems")
         return _Aggregate._finalise(self, event)
-        

--- a/pystrix/ami/core.py
+++ b/pystrix/ami/core.py
@@ -3,13 +3,13 @@ pystrix.ami.core
 ================
 
 Provides classes meant to be fed to a `Manager` instance's `send_action()` function.
- 
+
 Notes
 -----
 
 pystrix.ami.core_events contains event-definitions and processing rules for events raised by
 actions in this module (and some others, since extensions can use built-in features).
- 
+
 Legal
 -----
 
@@ -37,31 +37,31 @@ Authors:
 The requests implemented by this module follow the definitions provided by
 http://www.asteriskdocs.org/ and https://wiki.asterisk.org/
 """
+
 import hashlib
 import time
 
-from pystrix.ami.ami import (_Request, ManagerError)
-from pystrix.ami import core_events
-from pystrix.ami import generic_transforms
+from pystrix.ami import core_events, generic_transforms
+from pystrix.ami.ami import ManagerError, _Request
 
-AUTHTYPE_MD5 = 'MD5'  # Uses MD5 authentication when logging into AMI
+AUTHTYPE_MD5 = "MD5"  # Uses MD5 authentication when logging into AMI
 
 # Constants for use with the `Events` action
-EVENTMASK_ALL = 'on'
-EVENTMASK_NONE = 'off'
-EVENTMASK_CALL = 'call'
-EVENTMASK_LOG = 'log'
-EVENTMASK_SYSTEM = 'system'
+EVENTMASK_ALL = "on"
+EVENTMASK_NONE = "off"
+EVENTMASK_CALL = "call"
+EVENTMASK_LOG = "log"
+EVENTMASK_SYSTEM = "system"
 
 # Audio format constants
-FORMAT_SLN = 'sln'
-FORMAT_G723 = 'g723'
-FORMAT_G729 = 'g729'
-FORMAT_GSM = 'gsm'
-FORMAT_ALAW = 'alaw'
-FORMAT_ULAW = 'ulaw'
-FORMAT_VOX = 'vox'
-FORMAT_WAV = 'wav'
+FORMAT_SLN = "sln"
+FORMAT_G723 = "g723"
+FORMAT_G729 = "g729"
+FORMAT_GSM = "gsm"
+FORMAT_ALAW = "alaw"
+FORMAT_ULAW = "ulaw"
+FORMAT_VOX = "vox"
+FORMAT_WAV = "wav"
 
 # Originate result constants
 # https://github.com/asterisk/asterisk/blob/56028426de0692e8e36167251053c91b96e97c41/include/asterisk/frame.h#L277
@@ -75,44 +75,47 @@ ORIGINATE_RESULT_INCOMPLETE = 30  # Unable to resolve
 # Reason 0 is not documented in source
 # https://github.com/asterisk/asterisk/blob/56028426de0692e8e36167251053c91b96e97c41/main/manager.c#L5446
 # External reference https://www.voip-info.org/asterisk-manager-api-action-originate/
-ORIGINATE_RESULT_BAD_NUMBER = 0 #No such number/extension or bad technology
+ORIGINATE_RESULT_BAD_NUMBER = 0  # No such number/extension or bad technology
 ORIGINATE_RESULT_MAP = {
-    ORIGINATE_RESULT_BAD_NUMBER: 'BAD_NUMBER',
-    ORIGINATE_RESULT_REJECT: 'REJECTED',
-    ORIGINATE_RESULT_RING_LOCAL: 'RINGING',
-    ORIGINATE_RESULT_RING_REMOTE: 'RINGING',
-    ORIGINATE_RESULT_ANSWERED: 'ANSWERED',
-    ORIGINATE_RESULT_BUSY: 'BUSY',
-    ORIGINATE_RESULT_CONGESTION: 'CONGESTION',
-    ORIGINATE_RESULT_INCOMPLETE: 'INCOMPLETE'
+    ORIGINATE_RESULT_BAD_NUMBER: "BAD_NUMBER",
+    ORIGINATE_RESULT_REJECT: "REJECTED",
+    ORIGINATE_RESULT_RING_LOCAL: "RINGING",
+    ORIGINATE_RESULT_RING_REMOTE: "RINGING",
+    ORIGINATE_RESULT_ANSWERED: "ANSWERED",
+    ORIGINATE_RESULT_BUSY: "BUSY",
+    ORIGINATE_RESULT_CONGESTION: "CONGESTION",
+    ORIGINATE_RESULT_INCOMPLETE: "INCOMPLETE",
 }
 
 
 class AbsoluteTimeout(_Request):
     """
     Causes Asterisk to hang up a channel after a given number of seconds.
-    
+
     Requires call
     """
+
     def __init__(self, channel, seconds=0):
         """
         Causes the call on `channel` to be hung up after `seconds` have elapsed, defaulting to
         disabling auto-hangup.
         """
-        _Request.__init__(self, 'AbsoluteTimeout')
-        self['Channel'] = channel
-        self['Timeout'] = str(int(seconds))
+        _Request.__init__(self, "AbsoluteTimeout")
+        self["Channel"] = channel
+        self["Timeout"] = str(int(seconds))
+
 
 class AGI(_Request):
     """
     Causes Asterisk to execute an arbitrary AGI application in a call.
 
     Upon successful execution, an 'AsyncAGI' event is generated.
-    
+
     Requires call
     """
+
     _synchronous_events_finalising = (core_events.AsyncAGI,)
-    
+
     def __init__(self, channel, command, command_id=None):
         """
         `channel` is the call in which to execute `command`, the value passed to the AGI dialplan
@@ -120,11 +123,12 @@ class AGI(_Request):
         and can reasonably be set to a sequential digit or UUID in your application for tracking
         purposes.
         """
-        _Request.__init__(self, 'AGI')
-        self['Channel'] = channel
-        self['Command'] = command
+        _Request.__init__(self, "AGI")
+        self["Channel"] = channel
+        self["Command"] = command
         if command_id is not None:
-            self['CommandID'] = str(command_id)
+            self["CommandID"] = str(command_id)
+
 
 class Bridge(_Request):
     """
@@ -132,280 +136,319 @@ class Bridge(_Request):
 
     Requires call
     """
+
     def __init__(self, channel_1, channel_2, tone=False):
         """
         `channel_1` is the channel to which `channel_2` will be connected. `tone`, if `True`, will
         cause a sound to be played on `channel_2`.
         """
         _Request.__init__(self, "Bridge")
-        self['Channel1'] = channel_1
-        self['Channel2'] = channel_2
-        self['Tone'] = tone and 'yes' or 'no'
-        
+        self["Channel1"] = channel_1
+        self["Channel2"] = channel_2
+        self["Tone"] = tone and "yes" or "no"
+
+
 class Challenge(_Request):
     """
     Asks the AMI server for a challenge token to be used to hash the login secret.
-    
+
     The value provided under the returned response's 'Challenge' key must be passed as the
     'challenge' parameter of the `Login` object's constructor::
 
         login = Login(username='me', secret='password', challenge=response.get('Challenge'))
     """
+
     def __init__(self, authtype=AUTHTYPE_MD5):
         """
         `authtype` is used to specify the authentication type to be used.
         """
-        _Request.__init__(self, 'Challenge')
-        self['AuthType'] = authtype
-        
+        _Request.__init__(self, "Challenge")
+        self["AuthType"] = authtype
+
+
 class ChangeMonitor(_Request):
     """
     Changes the filename associated with the recording of a monitored channel. The channel must have
     previously been selected by the `Monitor` action.
-    
+
     Requires call
     """
+
     def __init__(self, channel, filename):
         """
         `channel` is the channel to be affected and `filename` is the new target filename, without
         extension, as either an auto-resolved or absolute path.
         """
-        _Request.__init__(self, 'ChangeMonitor')
-        self['Channel'] = channel
-        self['File'] = filename
-        
+        _Request.__init__(self, "ChangeMonitor")
+        self["Channel"] = channel
+        self["File"] = filename
+
+
 class Command(_Request):
     """
     Sends an arbitrary shell command to Asterisk, returning its response as a series of lines in the
     'data' attribute.
-    
+
     Requires command
     """
+
     def __init__(self, command):
         """
         `command` is the command to be executed.
         """
-        _Request.__init__(self, 'Command')
-        self['Command'] = command
+        _Request.__init__(self, "Command")
+        self["Command"] = command
+
 
 class CoreShowChannels(_Request):
     """
     Asks Asterisk to list all active channels.
-    
+
     Any number of 'CoreShowChannel' events may be generated in response to this request, followed by
     one 'CoreShowChannelsComplete'.
 
     Requires system
     """
+
     _aggregates = (core_events.CoreShowChannels_Aggregate,)
     _synchronous_events_list = (core_events.CoreShowChannel,)
     _synchronous_events_finalising = (core_events.CoreShowChannelsComplete,)
-    
+
     def __init__(self):
         _Request.__init__(self, "CoreShowChannels")
-        
+
+
 class CreateConfig(_Request):
     """
     Creates an empty configuration file, intended for use before `UpdateConfig()`.
 
     Requires config
     """
+
     def __init__(self, filename):
         """
         `filename` is the name of the file, with extension, to be created.
         """
         _Request.__init__(self, "CreateConfig")
-        self['Filename'] = filename
+        self["Filename"] = filename
+
 
 class DBDel(_Request):
     """
     Deletes a database value from Asterisk.
-    
+
     Requires system
     """
+
     def __init__(self, family, key):
         """
         `family` and `key` are specifiers to select the value to remove.
         """
-        _Request.__init__(self, 'DBDel')
-        self['Family'] = family
-        self['Key'] = key
+        _Request.__init__(self, "DBDel")
+        self["Family"] = family
+        self["Key"] = key
+
 
 class DBDelTree(_Request):
     """
     Deletes a database tree from Asterisk.
-    
+
     Requires system
     """
+
     def __init__(self, family, key=None):
         """
         `family` and `key` (optional) are specifiers to select the values to remove.
         """
-        _Request.__init__(self, 'DBDelTree')
-        self['Family'] = family
+        _Request.__init__(self, "DBDelTree")
+        self["Family"] = family
         if key is not None:
-            self['Key'] = key
-            
+            self["Key"] = key
+
+
 class DBGet(_Request):
     """
     Requests a database value from Asterisk.
-    
+
     A 'DBGetResponse' event will be generated upon success.
-    
+
     Requires system
     """
+
     def __init__(self, family, key):
         """
         `family` and `key` are specifiers to select the value to retrieve.
         """
-        _Request.__init__(self, 'DBGet')
-        self['Family'] = family
-        self['Key'] = key
-        
+        _Request.__init__(self, "DBGet")
+        self["Family"] = family
+        self["Key"] = key
+
+
 class DBPut(_Request):
     """
     Stores a database value in Asterisk.
-    
+
     Requires system
     """
+
     def __init__(self, family, key, value):
         """
         `family` and `key` are specifiers for where to place `value`.
         """
-        _Request.__init__(self, 'DBPut')
-        self['Family'] = family
-        self['Key'] = key
-        self['Val'] = value
-        
+        _Request.__init__(self, "DBPut")
+        self["Family"] = family
+        self["Key"] = key
+        self["Val"] = value
+
+
 class Events(_Request):
     """
     Changes the types of unsolicited events Asterisk sends to this manager connection.
     """
+
     def __init__(self, mask):
         """
         `Mask` is one of the following...
-        
+
         * EVENTMASK_ALL
         * EVENTMASK_NONE
-        
+
         ...or an iterable, like a tuple, with any combination of the following...
-        
+
         * EVENTMASK_CALL
         * EVENTMASK_LOG
         * EVENTMASK_SYSTEM
-        
+
         If an empty value is provided, EVENTMASK_NONE is assumed.
         """
-        _Request.__init__(self, 'Events')
+        _Request.__init__(self, "Events")
         if isinstance(mask, str):
-            self['EventMask'] = mask
+            self["EventMask"] = mask
         else:
             if EVENTMASK_ALL in mask:
-                self['EventMask'] = EVENTMASK_ALL
+                self["EventMask"] = EVENTMASK_ALL
             else:
-                self['EventMask'] = ','.join((m for m in mask if not m == EVENTMASK_NONE)) or EVENTMASK_NONE
-                
+                self["EventMask"] = (
+                    ",".join((m for m in mask if not m == EVENTMASK_NONE))
+                    or EVENTMASK_NONE
+                )
+
     def process_response(self, response):
         """
         Indicates success if the response matches one of the valid patterns.
         """
         response = _Request.process_response(self, response)
-        response.success = response.get('Response') in ('Events On', 'Events Off')
+        response.success = response.get("Response") in ("Events On", "Events Off")
         return response
-        
+
+
 class ExtensionState(_Request):
     """
     Provides the state of an extension.
-    
+
     If successful, a 'Status' key will be present, with one of the following values as a string:
-    
+
     * -2: Extension removed
     * -1: Extension hint not found
     *  0: Idle
     *  1: In use
     *  2: Busy
-    
+
     If non-negative, a 'Hint' key will be present, too, containing string data that can be helpful
     in discerning the current activity of the device.
-    
+
     Requires call
     """
+
     def __init__(self, extension, context):
         """
         `extension` is the extension to be checked and `context` is the container in which it
         resides.
         """
-        _Request.__init__(self, 'ExtensionState')
-        self['Exten'] = extension
-        self['Context'] = context
-        
+        _Request.__init__(self, "ExtensionState")
+        self["Exten"] = extension
+        self["Context"] = context
+
+
 class GetConfig(_Request):
     """
     Gets the contents of an Asterisk configuration file.
-    
+
     The result is recturned as a series of 'Line-XXXXXX-XXXXXX' keys that increment from 0
     sequentially, starting with 'Line-000000-000000'.
-    
+
     A sequential generator is provided by the 'get_lines()' function on the response.
-    
+
     Requires config
     """
+
     def __init__(self, filename):
         """
         `filename` is the name of the config file to be read, including extension.
         """
-        _Request.__init__(self, 'GetConfig')
-        self['Filename'] = filename
-        
+        _Request.__init__(self, "GetConfig")
+        self["Filename"] = filename
+
     def process_response(self, response):
         """
         Adds a 'get_lines' function that returns a generator that yields every line in order.
         """
         response = _Request.process_response(self, response)
-        response.get_lines = lambda : (value for (key, value) in sorted(response.items()) if key.startswith('Line-'))
+        response.get_lines = lambda: (
+            value
+            for (key, value) in sorted(response.items())
+            if key.startswith("Line-")
+        )
         return response
-        
+
+
 class Getvar(_Request):
     """
     Gets the value of a channel or global variable from Asterisk, returning the result under the
     'Value' key.
-    
+
     Requires call
     """
+
     def __init__(self, variable, channel=None):
         """
         `variable` is the name of the variable to retrieve. `channel` is optional; if not specified,
         a global variable is retrieved.
         """
-        _Request.__init__(self, 'Getvar')
-        self['Variable'] = variable
+        _Request.__init__(self, "Getvar")
+        self["Variable"] = variable
         if channel is not None:
-            self['Channel'] = channel
-            
+            self["Channel"] = channel
+
+
 class Hangup(_Request):
     """
     Hangs up a channel.
-    
+
     On success, a 'Hangup' event is generated.
-    
+
     Requires call
     """
+
     _synchronous_events_finalising = (core_events.Hangup,)
-    
+
     def __init__(self, channel):
         """
         `channel` is the ID of the channel to be hung up.
         """
-        _Request.__init__(self, 'Hangup')
-        self['Channel'] = channel
-        
+        _Request.__init__(self, "Hangup")
+        self["Channel"] = channel
+
+
 class ListCommands(_Request):
     """
     Provides a list of every command exposed by the Asterisk Management Interface, with synopsis,
     as a series of lines in the response's 'data' attribute.
     """
+
     def __init__(self):
-        _Request.__init__(self, 'ListCommands')
+        _Request.__init__(self, "ListCommands")
+
 
 class ListCategories(_Request):
     """
@@ -414,13 +457,14 @@ class ListCategories(_Request):
 
     Requires config
     """
+
     def __init__(self, filename):
         """
         `filename` is the name of the file, with extension, to be read.
         """
-        _Request.__init__(self, 'ListCategories')
-        self['Filename'] = filename
-        
+        _Request.__init__(self, "ListCategories")
+        self["Filename"] = filename
+
 
 class LocalOptimizeAway(_Request):
     """
@@ -429,101 +473,123 @@ class LocalOptimizeAway(_Request):
 
     Requires call
     """
+
     def __init__(self, channel):
         """
         `channel` is the channel to be optimised.
         """
-        _Request.__init__(self, 'LocalOptimizeAway')
-        self['Channel'] = channel
-        
+        _Request.__init__(self, "LocalOptimizeAway")
+        self["Channel"] = channel
+
+
 class Login(_Request):
     """
     Authenticates to the AMI server.
     """
-    def __init__(self, username, secret, events=True, challenge=None, authtype=AUTHTYPE_MD5):
+
+    def __init__(
+        self, username, secret, events=True, challenge=None, authtype=AUTHTYPE_MD5
+    ):
         """
         `username` and `secret` are the credentials used to authenticate.
-        
+
         `events` may be set to `False` to prevent unsolicited events from being received. This is
         normally not desireable, so leaving it `True` is usually a good idea.
-        
+
         If given, `challenge` is a challenge string provided by Asterisk after sending a `Challenge`
         action, used with `authtype` to determine how to authenticate. `authtype` is ignored if the
         `challenge` parameter is unset.
         """
-        _Request.__init__(self, 'Login')
-        self['Username'] = username
-        
+        _Request.__init__(self, "Login")
+        self["Username"] = username
+
         if challenge is not None and authtype:
-            self['AuthType'] = authtype
+            self["AuthType"] = authtype
             if authtype == AUTHTYPE_MD5:
-                self['Key'] = hashlib.md5(
+                self["Key"] = hashlib.md5(
                     generic_transforms.string_to_bytes(challenge + secret)
                 ).hexdigest()
             else:
-                raise ManagerAuthError("Invalid AuthType specified: %(authtype)s" % {
-                 'authtype': authtype,
-                })
+                raise ManagerAuthError(
+                    "Invalid AuthType specified: %(authtype)s"
+                    % {
+                        "authtype": authtype,
+                    }
+                )
         else:
-            self['Secret'] = secret
-            
+            self["Secret"] = secret
+
         if not events:
-            self['Events'] = 'off'
-            
+            self["Events"] = "off"
+
     def process_response(self, response):
         """
         Raises `ManagerAuthError` if an error is received while attempting to authenticate.
         """
-        if response.get('Response') == 'Error':
-            raise ManagerAuthError(response.get('Message'))
+        if response.get("Response") == "Error":
+            raise ManagerAuthError(response.get("Message"))
         return _Request.process_response(self, response)
-        
+
+
 class Logoff(_Request):
     """
     Logs out of the current manager session, permitting reauthentication.
     """
+
     def __init__(self):
-        _Request.__init__(self, 'Logoff')
-        
+        _Request.__init__(self, "Logoff")
+
+
 class MailboxCount(_Request):
     """
     Provides the number of new and old messages in the specified mailbox, keyed under 'NewMessages'
     and 'OldMessages', which contain ints; -1 indicates a failure while parsing the value.
     """
+
     def __init__(self, mailbox):
         """
         `mailbox` is the mailbox to check.
         """
-        _Request.__init__(self, 'MailboxCount')
-        self['Mailbox'] = mailbox
-        
+        _Request.__init__(self, "MailboxCount")
+        self["Mailbox"] = mailbox
+
     def process_response(self, response):
         """
         Converts the message-counts into integers.
         """
         response = _Request.process_response(self, response)
-        generic_transforms.to_int(response, ('NewMessages', 'OldMessages',), -1)
+        generic_transforms.to_int(
+            response,
+            (
+                "NewMessages",
+                "OldMessages",
+            ),
+            -1,
+        )
         return response
-        
+
+
 class MailboxStatus(_Request):
     """
     Provides the number of waiting messages in the specified mailbox, keyed under 'Waiting', which
     contains an int; -1 indicates a failure while parsing the value.
     """
+
     def __init__(self, mailbox):
         """
         `mailbox` is the mailbox to check.
         """
-        _Request.__init__(self, 'MailboxStatus')
-        self['Mailbox'] = mailbox
+        _Request.__init__(self, "MailboxStatus")
+        self["Mailbox"] = mailbox
 
     def process_response(self, response):
         """
         Converts the waiting-message-count into an integer.
         """
         response = _Request.process_response(self, response)
-        generic_transforms.to_int(response, ('Waiting',), -1)
+        generic_transforms.to_int(response, ("Waiting",), -1)
         return response
+
 
 class MixMonitorMute(_Request):
     """
@@ -531,22 +597,24 @@ class MixMonitorMute(_Request):
 
     Requires call
     """
+
     def __init__(self, channel, direction, mute):
         """
         `channel` is the channel to operate on.
 
         `direction` is one of the following:
-        
+
         * 'read': voice originating on the `channel`
         * 'write': voice delivered to the `channel`
         * 'both': all audio on the `channel`
 
         `mute` is `True` to muste the audio.
         """
-        _Request.__init__(self, 'MixMonitorMute')
-        self['Channel'] = channel
-        self['Direction'] = direction
-        self['State'] = mute and '1' or '0'
+        _Request.__init__(self, "MixMonitorMute")
+        self["Channel"] = channel
+        self["Direction"] = direction
+        self["State"] = mute and "1" or "0"
+
 
 class ModuleCheck(_Request):
     """
@@ -554,12 +622,14 @@ class ModuleCheck(_Request):
 
     If the module was loaded, its version is present in the response.
     """
+
     def __init__(self, module):
         """
         `module` is the name of the module, without extension.
         """
-        _Request.__init__(self, 'ModuleCheck')
-        self['Module'] = module
+        _Request.__init__(self, "ModuleCheck")
+        self["Module"] = module
+
 
 class ModuleLoad(_Request):
     """
@@ -567,17 +637,18 @@ class ModuleLoad(_Request):
 
     Requires system
     """
+
     def __init__(self, load_type, module=None):
         """
         `load_type` is one of the following:
-        
+
         * 'load'
         * 'unload'
         * 'reload': if `module` is undefined, all modules are reloaded
-        
+
         `module` is optionally the name of the module, with extension, or one of the following for
         a built-in subsystem:
-        
+
         * 'cdr'
         * 'dnsmgr'
         * 'enum'
@@ -586,24 +657,26 @@ class ModuleLoad(_Request):
         * 'manager'
         * 'rtp'
         """
-        _Request.__init__(self, 'ModuleLoad')
-        self['LoadType'] = load_type
+        _Request.__init__(self, "ModuleLoad")
+        self["LoadType"] = load_type
         if module is not None:
-            self['Module'] = module
-            
+            self["Module"] = module
+
+
 class Monitor(_Request):
     """
     Starts monitoring (recording) a channel.
-    
+
     Requires call
     """
-    def __init__(self, channel, filename, format='wav', mix=True):
+
+    def __init__(self, channel, filename, format="wav", mix=True):
         """
         `channel` is the channel to be affected and `filename` is the new target filename, without
         extension, as either an auto-resolved or absolute path.
 
         `format` may be any format Asterisk understands, defaulting to FORMAT_WAV:
-        
+
         * FORMAT_SLN
         * FORMAT_G723
         * FORMAT_G729
@@ -616,45 +689,59 @@ class Monitor(_Request):
         `mix`, defaulting to `True`, muxes both audio streams associated with the channel after
         recording is complete, with the alternative leaving the two streams separate.
         """
-        _Request.__init__(self, 'Monitor')
-        self['Channel'] = channel
-        self['File'] = filename
-        self['Format'] = format
-        self['Mix'] = mix and 'true' or 'false'
+        _Request.__init__(self, "Monitor")
+        self["Channel"] = channel
+        self["File"] = filename
+        self["Format"] = format
+        self["Mix"] = mix and "true" or "false"
+
 
 class MuteAudio(_Request):
     """
     Starts or stops muting audio on a channel.
 
     Either (or both) directions can be silenced.
-    
+
     Requires system
     """
+
     def __init__(self, channel, input=False, output=False, muted=False):
         """
         `channel` is the channel to be affected and `muted` indicates whether audio is being turned
         on or off. `input` (from the channel) and `output` (to the channel) indicate the subchannels
         to be adjusted.
         """
-        _Request.__init__(self, 'MuteAudio')
-        self['Channel'] = channel
+        _Request.__init__(self, "MuteAudio")
+        self["Channel"] = channel
         if input and output:
-            self['Direction'] = 'all'
+            self["Direction"] = "all"
         elif input:
-            self['Direction'] = 'in'
+            self["Direction"] = "in"
         elif output:
-            self['Direction'] = 'out'
+            self["Direction"] = "out"
         else:
-            raise ValueError("Unable to construct request that affects no audio subchannels")
-        self['State'] = muted and 'on' or 'off'
+            raise ValueError(
+                "Unable to construct request that affects no audio subchannels"
+            )
+        self["State"] = muted and "on" or "off"
+
 
 class _Originate(_Request):
     """
     Provides the common base for originated calls.
-    
+
     Requires call
     """
-    def __init__(self, channel, timeout=None, callerid=None, variables={}, account=None, async_=True):
+
+    def __init__(
+        self,
+        channel,
+        timeout=None,
+        callerid=None,
+        variables={},
+        account=None,
+        async_=True,
+    ):
         """
         Sets common parameters for originated calls.
 
@@ -679,31 +766,52 @@ class _Originate(_Request):
         `async_` should always be `True`. If not, only one unanswered call can be active at a time.
         """
         _Request.__init__(self, "Originate")
-        self['Channel'] = channel
-        self['Async'] = async_ and 'true' or 'false'
-        
+        self["Channel"] = channel
+        self["Async"] = async_ and "true" or "false"
+
         if timeout and timeout > 0:
-            self['Timeout'] = str(timeout)
-            self.timeout = timeout + 2000 #Timeout + 2s
+            self["Timeout"] = str(timeout)
+            self.timeout = timeout + 2000  # Timeout + 2s
         else:
-            self.timeout = 10 * 60 * 1000 #Ten minutes
+            self.timeout = 10 * 60 * 1000  # Ten minutes
 
         if callerid:
-            self['CallerID'] = callerid
+            self["CallerID"] = callerid
 
         if variables:
-            self['Variable'] = tuple(['%(key)s=%(value)s' % {'key': key, 'value': value,} for (key, value) in variables.items()])
+            self["Variable"] = tuple(
+                [
+                    "%(key)s=%(value)s"
+                    % {
+                        "key": key,
+                        "value": value,
+                    }
+                    for (key, value) in variables.items()
+                ]
+            )
 
         if account:
-            self['Account'] = account
-            
+            self["Account"] = account
+
+
 class Originate_Application(_Originate):
     """
     Initiates a call that answers, executes an arbitrary dialplan application, and hangs up.
-    
+
     Requires call
     """
-    def __init__(self, channel, application, data=(), timeout=None, callerid=None, variables={}, account=None, async_=True):
+
+    def __init__(
+        self,
+        channel,
+        application,
+        data=(),
+        timeout=None,
+        callerid=None,
+        variables={},
+        account=None,
+        async_=True,
+    ):
         """
         `channel` is the destination to be called, expressed as a fully qualified Asterisk channel,
         like "SIP/test-account@example.org".
@@ -729,18 +837,33 @@ class Originate_Application(_Originate):
 
         `async_` should always be `True`. If not, only one unanswered call can be active at a time.
         """
-        _Originate.__init__(self, channel, timeout, callerid, variables, account, async_)
-        self['Application'] = application
+        _Originate.__init__(
+            self, channel, timeout, callerid, variables, account, async_
+        )
+        self["Application"] = application
         if data:
-            self['Data'] = ','.join((str(d) for d in data))
-            
+            self["Data"] = ",".join((str(d) for d in data))
+
+
 class Originate_Context(_Originate):
     """
     Initiates a call with instructions derived from an arbitrary context/extension/priority.
-    
+
     Requires call
     """
-    def __init__(self, channel, context, extension, priority, timeout=None, callerid=None, variables={}, account=None, async_=True):
+
+    def __init__(
+        self,
+        channel,
+        context,
+        extension,
+        priority,
+        timeout=None,
+        callerid=None,
+        variables={},
+        account=None,
+        async_=True,
+    ):
         """
         `channel` is the destination to be called, expressed as a fully qualified Asterisk channel,
         like "SIP/test-account@example.org".
@@ -766,17 +889,21 @@ class Originate_Context(_Originate):
 
         `async_` should always be `True`. If not, only one unanswered call can be active at a time.
         """
-        _Originate.__init__(self, channel, timeout, callerid, variables, account, async_)
-        self['Context'] = context
-        self['Exten'] = extension
-        self['Priority'] = priority
-        
+        _Originate.__init__(
+            self, channel, timeout, callerid, variables, account, async_
+        )
+        self["Context"] = context
+        self["Exten"] = extension
+        self["Priority"] = priority
+
+
 class Park(_Request):
     """
     Parks a call for later retrieval.
 
     Requires call
     """
+
     def __init__(self, channel, channel_callback, timeout=None):
         """
         `channel` is the channel to be parked and `channel_callback` is the channel to which parking
@@ -786,10 +913,11 @@ class Park(_Request):
         if the call was not previously retrieved.
         """
         _Request.__init__(self, "Park")
-        self['Channel'] = channel
-        self['Channel2'] = channel_callback
+        self["Channel"] = channel
+        self["Channel2"] = channel_callback
         if timeout:
-            self['Timeout'] = str(timeout)
+            self["Timeout"] = str(timeout)
+
 
 class ParkedCalls(_Request):
     """
@@ -798,37 +926,42 @@ class ParkedCalls(_Request):
     Any number of 'ParkedCall' events may be generated in response to this request, followed by one
     'ParkedCallsComplete'.
     """
+
     _aggregates = (core_events.ParkedCalls_Aggregate,)
     _synchronous_events_list = (core_events.ParkedCall,)
     _synchronous_events_finalising = (core_events.ParkedCallsComplete,)
-    
+
     def __init__(self):
         _Request.__init__(self, "ParkedCalls")
+
 
 class PauseMonitor(_Request):
     """
     Pauses the recording of a monitored channel. The channel must have previously been selected by
     the `Monitor` action.
-    
+
     Requires call
     """
+
     def __init__(self, channel):
         """
         `channel` is the channel to be affected.
         """
-        _Request.__init__(self, 'PauseMonitor')
-        self['Channel'] = channel
-        
+        _Request.__init__(self, "PauseMonitor")
+        self["Channel"] = channel
+
+
 class Ping(_Request):
     """
     Pings the AMI server. The response value has a 'RTT' attribute, which is the number of seconds
     the trip took, as a floating-point number, or -1 in case of failure.
     """
-    _start_time = None #The time at which the ping message was built
-    
+
+    _start_time = None  # The time at which the ping message was built
+
     def __init__(self):
-        _Request.__init__(self, 'Ping')
-        
+        _Request.__init__(self, "Ping")
+
     def build_request(self, action_id, id_generator, **kwargs):
         """
         Records the time at which the request was assembled, to provide a latency value.
@@ -836,32 +969,35 @@ class Ping(_Request):
         request = _Request.build_request(self, action_id, id_generator, **kwargs)
         self._start_time = time.time()
         return request
-        
+
     def process_response(self, response):
         """
         Adds the number of seconds elapsed since the message was prepared for transmission under
         the 'RTT' key or sets it to -1 in case the server didn't respond as expected.
         """
         response = _Request.process_response(self, response)
-        if response.get('Response') == 'Pong':
-            response['RTT'] = time.time() - self._start_time
+        if response.get("Response") == "Pong":
+            response["RTT"] = time.time() - self._start_time
         else:
-            response['RTT'] = -1
+            response["RTT"] = -1
         return response
-        
+
+
 class PlayDTMF(_Request):
     """
     Plays a DTMF tone on a channel.
-    
+
     Requires call
     """
+
     def __init__(self, channel, digit):
         """
         `channel` is the channel to be affected, and `digit` is the tone to play.
         """
-        _Request.__init__(self, 'PlayDTMF')
-        self['Channel'] = channel
-        self['Digit'] = str(digit)
+        _Request.__init__(self, "PlayDTMF")
+        self["Channel"] = channel
+        self["Digit"] = str(digit)
+
 
 class QueueAdd(_Request):
     """
@@ -871,8 +1007,9 @@ class QueueAdd(_Request):
 
     Requires agent
     """
+
     _synchronous_events_finalising = (core_events.QueueMemberAdded,)
-    
+
     def __init__(self, interface, queue, membername=None, penalty=0, paused=False):
         """
         Adds the device identified by `interface` to the given `queue`.
@@ -882,12 +1019,13 @@ class QueueAdd(_Request):
         `paused` optinally allows the interface to start in a disabled state.
         """
         _Request.__init__(self, "QueueAdd")
-        self['Queue'] = queue
-        self['Interface'] = interface
-        self['Penalty'] = str(penalty)
-        self['Paused'] = paused and 'yes' or 'no'
+        self["Queue"] = queue
+        self["Interface"] = interface
+        self["Penalty"] = str(penalty)
+        self["Paused"] = paused and "yes" or "no"
         if membername:
-            self['MemberName'] = membername
+            self["MemberName"] = membername
+
 
 class QueueLog(_Request):
     """
@@ -895,6 +1033,7 @@ class QueueLog(_Request):
 
     Requires agent
     """
+
     def __init__(self, queue, event, interface=None, uniqueid=None, message=None):
         """
         `queue` is the queue to which the `event` is to be attached.
@@ -906,14 +1045,15 @@ class QueueLog(_Request):
         `message`'s purpose is presently unknown.
         """
         _Request.__init__(self, "QueueLog")
-        self['Queue'] = queue
-        self['Event'] = event
+        self["Queue"] = queue
+        self["Event"] = event
         if uniqueid is not None:
-            self['Uniqueid'] = uniqueid
+            self["Uniqueid"] = uniqueid
         if interface is not None:
-            self['Interface'] = interface
+            self["Interface"] = interface
         if message is not None:
-            self['Message'] = message
+            self["Message"] = message
+
 
 class QueuePause(_Request):
     """
@@ -923,16 +1063,18 @@ class QueuePause(_Request):
 
     Requires agent
     """
+
     def __init__(self, interface, paused, queue=None):
         """
         `interface` is the device to be affected, and `queue` optionally limits the scope to a
         single queue. `paused` must be `True` or `False`, to control the action being taken.
         """
         _Request.__init__(self, "QueuePause")
-        self['Interface'] = interface
-        self['Paused'] = paused and 'true' or 'false'
+        self["Interface"] = interface
+        self["Paused"] = paused and "true" or "false"
         if queue is not None:
-            self['Queue'] = queue
+            self["Queue"] = queue
+
 
 class QueuePenalty(_Request):
     """
@@ -940,16 +1082,18 @@ class QueuePenalty(_Request):
 
     Requires agent
     """
+
     def __init__(self, interface, penalty, queue=None):
         """
         Changes the `penalty` value associated with `interface` in all queues, unless `queue` is
         defined, limiting it to one.
         """
         _Request.__init__(self, "QueuePenalty")
-        self['Interface'] = interface
-        self['Penalty'] = str(penalty)
+        self["Interface"] = interface
+        self["Penalty"] = str(penalty)
         if queue is not None:
-            self['Queue'] = queue
+            self["Queue"] = queue
+
 
 class QueueReload(_Request):
     """
@@ -957,24 +1101,26 @@ class QueueReload(_Request):
 
     Requires agent
     """
-    def __init__(self, queue=None, members='yes', rules='yes', parameters='yes'):
+
+    def __init__(self, queue=None, members="yes", rules="yes", parameters="yes"):
         """
         Reloads parameters for all queues, unless `queue` is defined, limiting it to one.
 
         `members` is 'yes' (default) or 'no', indicating whether the member-list should be reloaded.
-        
+
         `rules` is 'yes' (default) or 'no', indicating whether the rule-list should be reloaded.
 
         `parameters` is 'yes' (default) or 'no', indicating whether the parameter-list should be
         reloaded.
         """
         _Request.__init__(self, "QueueReload")
-        self['Members'] = members
-        self['Rules'] = rules
-        self['Parameters'] = parameters
+        self["Members"] = members
+        self["Rules"] = rules
+        self["Parameters"] = parameters
         if queue is not None:
-            self['Queue'] = queue
-            
+            self["Queue"] = queue
+
+
 class QueueRemove(_Request):
     """
     Removes a member from a queue.
@@ -983,15 +1129,17 @@ class QueueRemove(_Request):
 
     Requires agent
     """
+
     _synchronous_events_finalising = (core_events.QueueMemberRemoved,)
-    
+
     def __init__(self, interface, queue):
         """
         Removes the device identified by `interface` from the given `queue`.
         """
         _Request.__init__(self, "QueueRemove")
-        self['Queue'] = queue
-        self['Interface'] = interface
+        self["Queue"] = queue
+        self["Interface"] = interface
+
 
 class QueueStatus(_Request):
     """
@@ -1000,19 +1148,24 @@ class QueueStatus(_Request):
     Upon success, 'QueueParams', 'QueueMember', and 'QueueEntry' events will be generated, ending
     with 'QueueStatusComplete'.
     """
+
     _aggregates = (core_events.QueueStatus_Aggregate,)
-    _synchronous_events_list = (core_events.QueueParams, core_events.QueueMember, core_events.QueueEntry,)
+    _synchronous_events_list = (
+        core_events.QueueParams,
+        core_events.QueueMember,
+        core_events.QueueEntry,
+    )
     _synchronous_events_finalising = (core_events.QueueStatusComplete,)
-    
+
     def __init__(self, queue=None):
         """
         Describes all queues in the system, unless `queue` is given, which limits the scope to one.
         """
         _Request.__init__(self, "QueueStatus")
         if queue is not None:
-            self['Queue'] = queue
+            self["Queue"] = queue
 
-         
+
 class QueueSummary(_Request):
     """
     Describes the Summary of one (or all) queues.
@@ -1020,6 +1173,7 @@ class QueueSummary(_Request):
     Upon success, 'QueueSummary' event will be generated, ending
     with 'QueueSummaryComplete'.
     """
+
     _aggregates = (core_events.QueueSummary_Aggregate,)
     _synchronous_events_list = (core_events.QueueSummary,)
     _synchronous_events_finalising = (core_events.QueueSummaryComplete,)
@@ -1030,15 +1184,16 @@ class QueueSummary(_Request):
         """
         _Request.__init__(self, "QueueSummary")
         if queue is not None:
-            self['Queue'] = queue
-          
-          
+            self["Queue"] = queue
+
+
 class Redirect(_Request):
     """
     Redirects a call to an arbitrary context/extension/priority.
-    
+
     Requires call
     """
+
     def __init__(self, channel, context, extension, priority):
         """
         `channel` is the destination to be redirected.
@@ -1048,17 +1203,19 @@ class Redirect(_Request):
         immediately.
         """
         _Request.__init__(self, "Redirect")
-        self['Channel'] = channel
-        self['Context'] = context
-        self['Exten'] = extension
-        self['Priority'] = priority
+        self["Channel"] = channel
+        self["Context"] = context
+        self["Exten"] = extension
+        self["Priority"] = priority
+
 
 class Reload(_Request):
     """
     Reloads Asterisk's configuration globally or for a specific module.
-    
+
     Requires call
     """
+
     def __init__(self, module=None):
         """
         If given, `module` limits the scope of the reload to a specific module, named without
@@ -1066,53 +1223,60 @@ class Reload(_Request):
         """
         _Request.__init__(self, "Reload")
         if module is not None:
-            self['Module'] = module
+            self["Module"] = module
+
 
 class SendText(_Request):
     """
     Sends text along a supporting channel.
-    
+
     Requires call
     """
+
     def __init__(self, channel, message):
         """
         `channel` is the channel along which to send `message`.
         """
         _Request.__init__(self, "SendText")
-        self['Channel'] = channel
-        self['Message'] = message
-        
+        self["Channel"] = channel
+        self["Message"] = message
+
+
 class SetCDRUserField(_Request):
     """
     Sets the user-field attribute for the CDR associated with a channel.
-    
+
     Requires call
     """
+
     def __init__(self, channel, user_field):
         """
         `channel` is the channel to be affected, and `user_field` is the value to set.
         """
-        _Request.__init__(self, 'SetCDRUserField')
-        self['Channel'] = channel
-        self['UserField'] = user_field
-        
+        _Request.__init__(self, "SetCDRUserField")
+        self["Channel"] = channel
+        self["UserField"] = user_field
+
+
 class Setvar(_Request):
     """
     Sets a channel-level or global variable.
-    
+
     Requires call
     """
+
     def __init__(self, variable, value, channel=None):
         """
         `value` is the value to be set under `variable`.
-        
+
         `channel` is the channel to be affected, or `None`, the default, if the variable is global.
         """
-        _Request.__init__(self, 'Setvar')
+        _Request.__init__(self, "Setvar")
         if channel:
-            self['Channel'] = channel
-        self['Variable'] = variable
-        self['Value'] = value
+            self["Channel"] = channel
+        self["Variable"] = variable
+        self["Value"] = value
+
 
 class SIPnotify(_Request):
     """
@@ -1120,6 +1284,7 @@ class SIPnotify(_Request):
 
     Requires call
     """
+
     def __init__(self, channel, headers={}):
         """
         `channel` is the channel along which to send the NOTIFY.
@@ -1127,9 +1292,19 @@ class SIPnotify(_Request):
         `headers` is a dictionary of key-value pairs to be inserted as SIP headers.
         """
         _Request.__init__(self, "SIPnotify")
-        self['Channel'] = channel
+        self["Channel"] = channel
         if headers:
-            self['Variable'] = tuple(['%(key)s=%(value)s' % {'key': key, 'value': value,} for (key, value) in headers.items()])
+            self["Variable"] = tuple(
+                [
+                    "%(key)s=%(value)s"
+                    % {
+                        "key": key,
+                        "value": value,
+                    }
+                    for (key, value) in headers.items()
+                ]
+            )
+
 
 class SIPpeers(_Request):
     """
@@ -1140,12 +1315,14 @@ class SIPpeers(_Request):
 
     Requires system
     """
+
     _aggregates = (core_events.SIPpeers_Aggregate,)
     _synchronous_events_list = (core_events.PeerEntry,)
     _synchronous_events_finalising = (core_events.PeerlistComplete,)
-    
+
     def __init__(self):
         _Request.__init__(self, "SIPpeers")
+
 
 class SIPqualify(_Request):
     """
@@ -1155,19 +1332,21 @@ class SIPqualify(_Request):
 
     Requires system
     """
+
     def __init__(self, peer):
         """
         `peer` is the peer to ping.
         """
         _Request.__init__(self, "SIPqualify")
-        self['Peer'] = peer
+        self["Peer"] = peer
+
 
 class SIPshowpeer(_Request):
     r"""
     Provides detailed information about a SIP peer.
 
     The response has the following key-value pairs:
-    
+
     * 'ACL': True or False
     * 'Address-IP': The IP of the peer
     * 'Address-Port': The port of the peer, as an integer
@@ -1179,10 +1358,10 @@ class SIPshowpeer(_Request):
     * 'ChanObjectType': "peer"
     * 'CID-CallingPres': ?
     * 'Context': The context associated with the peer
-    
+
      * 'CodecOrder': The order in which codecs are tried
      * 'Codecs': A list of supported codecs
-     
+
     * 'Default-addr-IP': ?
     * 'Default-addr-port': ?
     * 'Default-Username': ?
@@ -1213,37 +1392,54 @@ class SIPshowpeer(_Request):
     * 'ToHost': ?
     * 'TransferMode': "open"
     * 'VoiceMailbox': The mailbox associated with the peer; may be null
-    
+
     Requires system
     """
+
     def __init__(self, peer):
         """
         `peer` is the identifier of the peer for which information is to be retrieved.
         """
         _Request.__init__(self, "SIPshowpeer")
-        self['Peer'] = peer
-        
+        self["Peer"] = peer
+
     def process_response(self, response):
         """
         Sets the 'ACL', 'Dynamic', 'MD5SecretExist', 'SecretExist', 'SIP-CanReinvite',
         'SIP-PromiscRedir', 'SIP-UserPhone', 'SIP-VideoSupport', and 'SIP-AuthInsecure' headers'
         values to booleans.
-        
+
         Sets the 'Address-Port', 'MaxCallBR', and 'RegExpire' headers' values to ints, with -1
         indicating failure.
         """
         response = _Request.process_response(self, response)
-        
-        generic_transforms.to_bool(response, (
-         'ACL', 'Dynamic', 'MD5SecretExist', 'SecretExist', 'SIP-CanReinvite', 'SIP-PromiscRedir',
-         'SIP-UserPhone', 'SIP-VideoSupport',
-        ), truth_value='Y')
-        generic_transforms.to_bool(response, ('SIP-AuthInsecure',), truth_value='yes')
-        generic_transforms.to_int(response, ('Address-Port',), -1)
-        generic_transforms.to_int(response, ('MaxCallBR', 'RegExpire'), -1, preprocess=(lambda x:x.split()[0]))
-        
+
+        generic_transforms.to_bool(
+            response,
+            (
+                "ACL",
+                "Dynamic",
+                "MD5SecretExist",
+                "SecretExist",
+                "SIP-CanReinvite",
+                "SIP-PromiscRedir",
+                "SIP-UserPhone",
+                "SIP-VideoSupport",
+            ),
+            truth_value="Y",
+        )
+        generic_transforms.to_bool(response, ("SIP-AuthInsecure",), truth_value="yes")
+        generic_transforms.to_int(response, ("Address-Port",), -1)
+        generic_transforms.to_int(
+            response,
+            ("MaxCallBR", "RegExpire"),
+            -1,
+            preprocess=(lambda x: x.split()[0]),
+        )
+
         return response
-        
+
+
 class SIPshowregistry(_Request):
     """
     Lists all SIP registrations.
@@ -1253,13 +1449,15 @@ class SIPshowregistry(_Request):
 
     Requires system
     """
+
     _aggregates = (core_events.SIPshowregistry_Aggregate,)
     _synchronous_events_list = (core_events.RegistryEntry,)
     _synchronous_events_finalising = (core_events.RegistrationsComplete,)
-    
+
     def __init__(self):
         _Request.__init__(self, "SIPshowregistry")
-        
+
+
 class Status(_Request):
     """
     Lists the status of an active channel.
@@ -1268,44 +1466,50 @@ class Status(_Request):
 
     Requires call
     """
+
     _aggregates = (core_events.Status_Aggregate,)
     _synchronous_events_list = (core_events.Status,)
     _synchronous_events_finalising = (core_events.StatusComplete,)
-    
+
     def __init__(self, channel):
         """
         `channel` is the channel for which status information is to be retrieved.
         """
         _Request.__init__(self, "Status")
-        self['channel'] = channel
+        self["channel"] = channel
+
 
 class StopMonitor(_Request):
     """
     Stops recording a monitored channel. The channel must have previously been selected by
     the `Monitor` action.
-    
+
     Requires call
     """
+
     def __init__(self, channel):
         """
         `channel` is the channel to be affected.
         """
-        _Request.__init__(self, 'StopMonitor')
-        self['Channel'] = channel
+        _Request.__init__(self, "StopMonitor")
+        self["Channel"] = channel
+
 
 class UnpauseMonitor(_Request):
     """
     Unpauses recording on a monitored channel. The channel must have previously been selected by
     the `Monitor` action.
-    
+
     Requires call
     """
+
     def __init__(self, channel):
         """
         `channel` is the channel to be affected.
         """
-        _Request.__init__(self, 'UnpauseMonitor')
-        self['Channel'] = channel
+        _Request.__init__(self, "UnpauseMonitor")
+        self["Channel"] = channel
+
 
 class UpdateConfig(_Request):
     """
@@ -1313,6 +1517,7 @@ class UpdateConfig(_Request):
 
     Requires config
     """
+
     def __init__(self, src_filename, dst_filename, changes, reload=True):
         """
         Reads from `src_filename`, performing all `changes`, and writing to `dst_filename`.
@@ -1321,76 +1526,84 @@ class UpdateConfig(_Request):
         module, that module is reloaded.
 
         `changes` may be any iterable object countaining quintuples with the following items:
-        
+
         #. One of the following:
-        
+
          * 'NewCat': creates a new category
          * 'RenameCat': renames a category
          * 'DelCat': deletes a category
          * 'Update': changes a value
          * 'Delete': removes a value
          * 'Append': adds a value
-         
+
         2. The name of the category to operate on
         #. `None` or the name of the variable to operate on
         #. `None` or the value to be set/added (has no effect with 'Delete')
         #. `None` or a string that needs to be matched in the line to serve as a qualifier
         """
         _Request.__init__(self, "UpdateConfig")
-        self['SrcFilename'] = src_filename
-        self['DstFilename'] = dst_filename
-        self['Reload'] = type(reload) == bool and (reload and 'true' or 'false') or reload  # noqa: E721
+        self["SrcFilename"] = src_filename
+        self["DstFilename"] = dst_filename
+        self["Reload"] = (
+            type(reload) == bool  # noqa: E721
+            and (reload and "true" or "false")
+            or reload
+        )
 
-        for (i, (action, category, variable, value, match)) in enumerate(changes):
-            index = '%(index)06i' % {
-             'index': i,
+        for i, (action, category, variable, value, match) in enumerate(changes):
+            index = "%(index)06i" % {
+                "index": i,
             }
-            self['Action-' + index] = action
-            self['Cat-' + index] = category
+            self["Action-" + index] = action
+            self["Cat-" + index] = category
             if variable is not None:
-                self['Var-' + index] = variable
+                self["Var-" + index] = variable
             if value is not None:
-                self['Value-' + index] = value
+                self["Value-" + index] = value
             if match is not None:
-                self['Match-' + index] = match
+                self["Match-" + index] = match
+
 
 class UserEvent(_Request):
     """
     Causes a 'UserEvent' event to be generated.
-    
+
     Requires user
     """
+
     _synchronous_events_finalising = (core_events.UserEvent,)
-    
+
     def __init__(self, **kwargs):
         """
         Any keyword-arguments passed will be present in the generated event, making this usable as a
         crude form of message-passing between AMI clients.
         """
-        _Request.__init__(self, 'UserEvent')
-        for (key, value) in kwargs.items():
+        _Request.__init__(self, "UserEvent")
+        for key, value in kwargs.items():
             self[key] = value
+
 
 class VoicemailUsersList(_Request):
     """
     Lists all voicemail information.
-    
+
     Any number of 'VoicemailUserEntry' events may be generated in response to this request, followed
     by one 'VoicemailUserEntryComplete'.
-    
+
     Requires system (probably)
     """
+
     _aggregates = (core_events.VoicemailUsersList_Aggregate,)
     _synchronous_events_list = (core_events.VoicemailUserEntry,)
     _synchronous_events_finalising = (core_events.VoicemailUserEntryComplete,)
-    
+
     def __init__(self):
-        _Request.__init__(self, 'VoicemailUsersList')
+        _Request.__init__(self, "VoicemailUsersList")
 
 
-#Exceptions
+# Exceptions
 ###############################################################################
 class ManagerAuthError(ManagerError):
     """
-    Indicates that a problem occurred while authenticating 
+    Indicates that a problem occurred while authenticating
     """

--- a/pystrix/ami/core_events.py
+++ b/pystrix/ami/core_events.py
@@ -31,16 +31,17 @@ Authors:
 The events implemented by this module follow the definitions provided by
 http://www.asteriskdocs.org/ and https://wiki.asterisk.org/
 """
+
 import re
 
-from pystrix.ami.ami import (_Aggregate, _Event)
 from pystrix.ami import generic_transforms
+from pystrix.ami.ami import _Aggregate, _Event
 
 
 class AGIExec(_Event):
     """
     Generated when an AGI script executes an arbitrary application.
-    
+
     - 'Channel': The channel in use
     - 'Command': The command that was issued
     - 'CommandId': The command's identifier, used to track events from start to finish
@@ -48,50 +49,54 @@ class AGIExec(_Event):
     - 'Result': Only present when 'SubEvent' is "End": "Success" (and "Failure"?)
     - 'ResultCode': Only present when 'SubEvent' is "End": the result-code from Asterisk
     """
+
     def process(self):
         """
         Translates the 'Result' header's value into a bool.
-        
+
         Translates the 'ResultCode' header's value into an int, setting it to `-1` if coercion
         fails.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_bool(headers, ('Result',), truth_value='Success')
-        generic_transforms.to_int(headers, ('ResultCode',), -1)
-        
+
+        generic_transforms.to_bool(headers, ("Result",), truth_value="Success")
+        generic_transforms.to_int(headers, ("ResultCode",), -1)
+
         return (headers, data)
-        
+
+
 class AsyncAGI(_Event):
     """
     Generated when an AGI request is processed.
-    
+
     - All fields currently unknown
     """
-    
+
+
 class ChannelUpdate(_Event):
     """
     Describes a change in a channel.
-    
+
     Some fields are type-dependent and will appear as children of that type in the list.
-    
+
     - 'Channel': The channel being described
     - 'Channeltype': One of the following types
-    
+
      - 'SIP': SIP channels have the following fields
-     
+
       - 'SIPcallid': 'DB45B1B5-1EAD11E1-B979D0B6-32548E42@10.13.38.201', the CallID negotiated with
         the endpoint; this should be present in any CDRs generated
       - 'SIPfullcontact': 'sip:flan@uguu.ca', the address of the SIP contact field, if any (observed
         during a REFER)
-    
+
     - 'UniqueID': An Asterisk-unique value
     """
-    
+
+
 class CoreShowChannel(_Event):
     """
     Provides the definition of an active Asterisk channel.
-    
+
     - 'AccountCode': The account code associated with the channel
     - 'Application': The application currently being executed by the channel
     - 'ApplicationData': The arguments provided to the application
@@ -105,7 +110,7 @@ class CoreShowChannel(_Event):
      - '0': Not connected
      - '4': Alerting
      - '6': Connected
-     
+
     - 'ChannelStateDesc': A lexical description of the channel's current state
     - 'ConnectedLineNum': The (often) numeric address of the called party (may be nil)
     - 'ConnectedLineName': The (optional, media-specific) name of the called party (may be nil)
@@ -115,50 +120,55 @@ class CoreShowChannel(_Event):
     - 'Priority': The dialplan priority in which the channel is executing
     - 'UniqueID': An Asterisk-unique value (the timestamp at which the channel was connected?)
     """
+
     def process(self):
         """
         Translates the 'ChannelState' header's value into an int, setting it to `None` if coercion
         fails.
-        
+
         Replaces the 'Duration' header's value with the number of seconds, as an int, or -1 if
         conversion fails.
         """
         (headers, data) = _Event.process(self)
-        
+
         try:
-            (h, m, s) = (int(v) for v in headers['Duration'].split(':'))
-            headers['Duration'] = s + m * 60 + h * 60 * 60
+            (h, m, s) = (int(v) for v in headers["Duration"].split(":"))
+            headers["Duration"] = s + m * 60 + h * 60 * 60
         except Exception:
-            headers['Duration'] = -1
-            
-        generic_transforms.to_int(headers, ('ChannelState',), None)
-        
+            headers["Duration"] = -1
+
+        generic_transforms.to_int(headers, ("ChannelState",), None)
+
         return (headers, data)
-        
+
+
 class CoreShowChannelsComplete(_Event):
     """
     Indicates that all Asterisk channels have been listed.
-    
+
     - 'ListItems' : The number of items returned prior to this event
     """
+
     def process(self):
         """
         Translates the 'ListItems' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_int(headers, ('ListItems',), -1)
-        
+
+        generic_transforms.to_int(headers, ("ListItems",), -1)
+
         return (headers, data)
-        
+
+
 class DBGetResponse(_Event):
     """
     Provides the value requested from the database.
-    
+
     - 'Family': The family of the value being provided
     - 'Key': The key of the value being provided
     - 'Val': The value being provided, represented as a string
     """
+
 
 class DTMF(_Event):
     """
@@ -170,44 +180,56 @@ class DTMF(_Event):
       `Begin`, though both may be `Yes` if the event has no duration)
     - 'UniqueID': An Asterisk-unique value
     """
+
     def process(self):
         """
         Translates 'Begin' and 'End' into booleans, and adds a 'Received':bool header.
         """
         (headers, data) = _Event.process(self)
-        
-        headers['Received'] = headers.get('Direction') == 'Received'
-        generic_transforms.to_bool(headers, ('Begin', 'End',), truth_value='Yes')
-        
+
+        headers["Received"] = headers.get("Direction") == "Received"
+        generic_transforms.to_bool(
+            headers,
+            (
+                "Begin",
+                "End",
+            ),
+            truth_value="Yes",
+        )
+
         return (headers, data)
-        
+
+
 class FullyBooted(_Event):
     """
     Indicates that Asterisk is online.
-    
+
     - 'Status': "Fully Booted"
     """
-    
+
+
 class Hangup(_Event):
     """
     Indicates that a channel has been hung up.
-    
+
     - 'Cause': One of the following numeric values, as a string:
-    
+
      - '0': Hung up
      - '16': Normal clearing
-     
+
     - 'Cause-txt': Additional information related to the hangup
     - 'Channel': The channel hung-up
     - 'Uniqueid': An Asterisk unique value
     """
+
     def process(self):
         """
         Translates the 'Cause' header's value into an int, setting it to `None` if coercion fails.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('Cause',), None)
+        generic_transforms.to_int(headers, ("Cause",), None)
         return (headers, data)
+
 
 class HangupRequest(_Event):
     """
@@ -217,30 +239,34 @@ class HangupRequest(_Event):
     - 'Uniqueid': An Asterisk unique value
     """
 
+
 class MonitorStart(_Event):
     """
     Indicates that monitoring has begun.
-    
+
     - 'Channel': The channel being monitored
     - 'Uniqueid': An Asterisk unique value
     """
 
+
 class MonitorStop(_Event):
     """
     Indicates that monitoring has ceased.
-    
+
     - 'Channel': The channel that was monitored
     - 'Uniqueid': An Asterisk unique value
     """
 
+
 class NewAccountCode(_Event):
     """
     Indicates that the account-code associated with a channel has changed.
-    
+
     - 'AccountCode': The new account code
     - 'Channel': The channel that was affected.
     - 'OldAccountCode': The old account code
     """
+
 
 class Newchannel(_Event):
     """
@@ -261,14 +287,16 @@ class Newchannel(_Event):
     - 'Exten': The extension the channel is currently operating in
     - 'Uniqueid': An Asterisk unique value
     """
+
     def process(self):
         """
         Translates the 'ChannelState' header's value into an int, setting it to `None` if coercion
         fails.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('ChannelState',), None)
+        generic_transforms.to_int(headers, ("ChannelState",), None)
         return (headers, data)
+
 
 class Newexten(_Event):
     """
@@ -282,6 +310,7 @@ class Newexten(_Event):
     - 'Priority': The priority the channel is currently operating in
     - 'Uniqueid': An Asterisk unique value
     """
+
 
 class Newstate(_Event):
     """
@@ -301,19 +330,21 @@ class Newstate(_Event):
     - 'ConnectedLineName': ?
     - 'Uniqueid': An Asterisk unique value
     """
+
     def process(self):
         """
         Translates the 'ChannelState' header's value into an int, setting it to `None` if coercion
         fails.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('ChannelState',), None)
+        generic_transforms.to_int(headers, ("ChannelState",), None)
         return (headers, data)
-        
+
+
 class OriginateResponse(_Event):
     """
     Describes the result of an Originate request.
-    
+
     * 'CallerIDName': The supplied source name
     * 'CallerIDNum': The supplied source address
     * 'Channel': The Asterisk channel used for the call
@@ -321,21 +352,26 @@ class OriginateResponse(_Event):
     * 'Exten': The dialplan extension into which the call was placed, as a string; unused for applications
     * 'Reason': An integer as a string, ostensibly one of the `ORIGINATE_RESULT` constants; undefined integers may exist
     """
+
     def process(self):
         """
         Sets the 'Reason' values to an int, one of the `ORIGINATE_RESULT` constants, with -1
         indicating failure.
         """
-        from pystrix.ami.core import ORIGINATE_RESULT_MAP  # import here to prevent circular imports
+        from pystrix.ami.core import (
+            ORIGINATE_RESULT_MAP,  # import here to prevent circular imports
+        )
+
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('Reason',), -1)
-        generic_transforms.add_result(headers, 'Reason', ORIGINATE_RESULT_MAP)
+        generic_transforms.to_int(headers, ("Reason",), -1)
+        generic_transforms.add_result(headers, "Reason", ORIGINATE_RESULT_MAP)
         return (headers, data)
-        
+
+
 class ParkedCall(_Event):
     """
     Describes a parked call.
-    
+
     - 'CallerID': The ID of the caller, ".+?" <.+?>
     - 'CallerIDName' (optional): The name of the caller, on supporting channels
     - 'Channel': The channel of the parked call
@@ -344,43 +380,47 @@ class ParkedCall(_Event):
     - 'Timeout' (optional): The time remaining before the call is reconnected with the callback
       channel
     """
+
     def process(self):
         """
         Translates the 'Timeout' header's value into an int, setting it to `None` if coercion
         fails, and leaving it absent if it wasn't present in the original response.
         """
         (headers, data) = _Event.process(self)
-        if 'Timeout' in headers:
-            generic_transforms.to_int(headers, ('Timeout',), None)
+        if "Timeout" in headers:
+            generic_transforms.to_int(headers, ("Timeout",), None)
         return (headers, data)
-        
+
+
 class ParkedCallsComplete(_Event):
     """
     Indicates that all parked calls have been listed.
-    
+
     - 'Total' : The number of items returned prior to this event
     """
+
     def process(self):
         """
         Translates the 'Total' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('Total',), -1)
+        generic_transforms.to_int(headers, ("Total",), -1)
         return (headers, data)
+
 
 class PeerEntry(_Event):
     """
     Describes a peer.
-    
+
     - 'ChannelType': The type of channel being described.
-    
+
      - 'SIP'
-     
+
     - 'ObjectName': The internal name by which this peer is known
     - 'ChanObjectType': The type of object
-    
+
      - 'peer'
-     
+
     - 'IPaddress' (optional): The IP of the peer
     - 'IPport' (optional): The port of the peer
     - 'Dynamic': 'yes' or 'no', depending on whether the peer is resolved by IP or authentication
@@ -391,52 +431,62 @@ class PeerEntry(_Event):
     - 'Status': 'Unmonitored', 'OK (\\d+ ms)'
     - 'RealtimeDevice': 'yes' or 'no'
     """
+
     def process(self):
         """
         Translates the 'Port' header's value into an int, setting it to `None` if coercion
         fails, and leaving it absent if it wasn't present in the original response.
-        
+
         Translates the 'Dynamic', 'Natsupport', 'VideoSupport', 'ACL', and 'RealtimeDevice' headers'
         values into bools.
-        
+
         Translates 'Status' into the number of milliseconds since the peer was last seen or -2 if
         unmonitored. -1 if parsing failed.
         """
         (headers, data) = _Event.process(self)
-        
+
         try:
-            if headers['Status'] == 'Unmonitored':
-                headers['Status'] = -2
+            if headers["Status"] == "Unmonitored":
+                headers["Status"] = -2
             else:
-                headers['Status'] = int(re.match(r'OK \((\d+) ms\)', headers['Status']).group(1))
+                headers["Status"] = int(
+                    re.match(r"OK \((\d+) ms\)", headers["Status"]).group(1)
+                )
         except Exception:
-            headers['Status'] = -1
-            
-        if 'IPport' in headers:
-            generic_transforms.to_int(headers, ('IPPort',), None)
-            
-        generic_transforms.to_bool(headers, ('Dynamic', 'Natsupport', 'VideoSupport', 'ACL', 'RealtimeDevice'), truth_value='yes')
-        
+            headers["Status"] = -1
+
+        if "IPport" in headers:
+            generic_transforms.to_int(headers, ("IPPort",), None)
+
+        generic_transforms.to_bool(
+            headers,
+            ("Dynamic", "Natsupport", "VideoSupport", "ACL", "RealtimeDevice"),
+            truth_value="yes",
+        )
+
         return (headers, data)
+
 
 class PeerlistComplete(_Event):
     """
     Indicates that all peers have been listed.
-    
+
     - 'ListItems' : The number of items returned prior to this event
     """
+
     def process(self):
         """
         Translates the 'ListItems' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('ListItems',), -1)
+        generic_transforms.to_int(headers, ("ListItems",), -1)
         return (headers, data)
+
 
 class QueueEntry(_Event):
     """
     Indicates that a call is waiting to be answered.
-    
+
     - 'Channel': The channel of the inbound call
     - 'CallerID': The (often) numeric ID of the caller
     - 'CallerIDName' (optional): The friendly name of the caller on supporting channels
@@ -444,18 +494,27 @@ class QueueEntry(_Event):
     - 'Queue': The queue in which the caller is waiting
     - 'Wait': The number of seconds the caller has been waiting
     """
+
     def process(self):
         """
         Translates the 'Position' and 'Wait' headers' values into ints, setting them to -1 on error.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('Position', 'Wait',), -1)
+        generic_transforms.to_int(
+            headers,
+            (
+                "Position",
+                "Wait",
+            ),
+            -1,
+        )
         return (headers, data)
+
 
 class QueueMember(_Event):
     """
     Describes a member of a queue.
-    
+
     - 'CallsTaken': The number of calls received by this member
     - 'LastCall': The UNIX timestamp of the last call taken, or 0 if none
     - 'Location': The interface in the queue
@@ -465,27 +524,38 @@ class QueueMember(_Event):
     - 'Penalty': The selection penalty to apply to this member (higher numbers mean later selection)
     - 'Queue': The queue to which the member belongs
     - 'Status': One of the following, as a string:
-    
+
      - '0': Idle
      - '1': In use
      - '2': Busy
     """
+
     def process(self):
         """
         Translates the 'CallsTaken', 'LastCall', 'Penalty', and 'Status' headers' values into ints,
         setting them to -1 on error.
-        
+
         'Paused' is set to a bool.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_bool(headers, ('Paused',), truth_value='1')
-        generic_transforms.to_int(headers, ('CallsTaken', 'LastCall', 'Penalty', 'Status',), -1)
+        generic_transforms.to_bool(headers, ("Paused",), truth_value="1")
+        generic_transforms.to_int(
+            headers,
+            (
+                "CallsTaken",
+                "LastCall",
+                "Penalty",
+                "Status",
+            ),
+            -1,
+        )
         return (headers, data)
-        
+
+
 class QueueMemberAdded(_Event):
     """
     Indicates that a member was added to a queue.
-    
+
     - 'CallsTaken': The number of calls received by this member
     - 'LastCall': The UNIX timestamp of the last call taken, or 0 if none
     - 'Location': The interface added to the queue
@@ -495,53 +565,67 @@ class QueueMemberAdded(_Event):
     - 'Penalty': The selection penalty to apply to this member (higher numbers mean later selection)
     - 'Queue': The queue to which the member was added
     - 'Status': One of the following, as a string:
-    
+
      - '0': Idle
      - '1': In use
      - '2': Busy
     """
+
     def process(self):
         """
         Translates the 'CallsTaken', 'LastCall', 'Penalty', and 'Status' headers' values into ints,
         setting them to -1 on error.
-        
+
         'Paused' is set to a bool.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_bool(headers, ('Paused',), truth_value='1')
-        generic_transforms.to_int(headers, ('CallsTaken', 'LastCall', 'Penalty', 'Status',), -1)
+        generic_transforms.to_bool(headers, ("Paused",), truth_value="1")
+        generic_transforms.to_int(
+            headers,
+            (
+                "CallsTaken",
+                "LastCall",
+                "Penalty",
+                "Status",
+            ),
+            -1,
+        )
         return (headers, data)
-        
+
+
 class QueueMemberPaused(_Event):
     """
     Indicates that the pause-state of a queue member was changed.
-    
+
     - 'Location': The interface added to the queue
     - 'MemberName' (optional): The friendly name of the member
     - 'Paused': '1' or '0' for 'true' and 'false', respectively
     - 'Queue': The queue in which the member was paused
     """
+
     def process(self):
         """
         'Paused' is set to a bool.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_bool(headers, ('Paused',), truth_value='1')
+        generic_transforms.to_bool(headers, ("Paused",), truth_value="1")
         return (headers, data)
+
 
 class QueueMemberRemoved(_Event):
     """
     Indicates that a member was removed from a queue.
-    
+
     - 'Location': The interface removed from the queue
     - 'MemberName' (optional): The friendly name of the member
     - 'Queue': The queue from which the member was removed
     """
-    
+
+
 class QueueParams(_Event):
     """
     Describes the attributes of a queue.
-    
+
     - 'Abandoned': The number of calls that have gone unanswered
     - 'Calls': The number of current calls in the queue
     - 'Completed': The number of completed calls
@@ -552,23 +636,44 @@ class QueueParams(_Event):
     - 'ServiceLevelPerf': ?
     - 'Weight': ?
     """
+
     def process(self):
         """
         Translates the 'Abandoned', 'Calls', 'Completed', 'Holdtime', and 'Max' headers' values into
         ints, setting them to -1 on error.
-        
+
         Translates the 'ServiceLevel', 'ServiceLevelPerf', and 'Weight' values into
         floats, setting them to -1 on error.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('Abandoned', 'Calls', 'Completed', 'Holdtime', 'Max',), -1)
-        generic_transforms.to_float(headers, ('ServiceLevel', 'ServiceLevelPref', 'Weight',), -1)
+        generic_transforms.to_int(
+            headers,
+            (
+                "Abandoned",
+                "Calls",
+                "Completed",
+                "Holdtime",
+                "Max",
+            ),
+            -1,
+        )
+        generic_transforms.to_float(
+            headers,
+            (
+                "ServiceLevel",
+                "ServiceLevelPref",
+                "Weight",
+            ),
+            -1,
+        )
         return (headers, data)
-        
+
+
 class QueueStatusComplete(_Event):
     """
     Indicates that a QueueStatus request has completed.
     """
+
 
 class QueueSummary(_Event):
     """
@@ -589,12 +694,22 @@ class QueueSummary(_Event):
 
     def process(self):
         """
-            Translates the 'LoggedIn', 'Available', 'Callers', 'Holdtime', 'TalkTime' and 'LongestHoldTime' headers'
-            values into ints, setting them to -1 on error.
+        Translates the 'LoggedIn', 'Available', 'Callers', 'Holdtime', 'TalkTime' and 'LongestHoldTime' headers'
+        values into ints, setting them to -1 on error.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('LoggedIn', 'Available', 'Callers', 'HoldTime', 'TalkTime',
-                                            'LongestHoldTime'), -1)
+        generic_transforms.to_int(
+            headers,
+            (
+                "LoggedIn",
+                "Available",
+                "Callers",
+                "HoldTime",
+                "TalkTime",
+                "LongestHoldTime",
+            ),
+            -1,
+        )
         return (headers, data)
 
 
@@ -607,7 +722,7 @@ class QueueSummaryComplete(_Event):
 class RegistryEntry(_Event):
     """
     Describes a SIP registration.
-    
+
     - 'Domain': The domain in which the registration took place
     - 'DomainPort': The port in use in the registration domain
     - 'Host': The address of the host
@@ -617,38 +732,52 @@ class RegistryEntry(_Event):
     - 'State': The current status of the registration
     - 'Username': The username used for the registration
     """
+
     def process(self):
         """
         Translates the 'DomainPort', 'Port', 'Refresh', and 'RegistrationTime' values into ints,
         setting them to -1 on error.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('DomainPort', 'Port', 'Refresh', 'RegistrationTime',), -1)
+        generic_transforms.to_int(
+            headers,
+            (
+                "DomainPort",
+                "Port",
+                "Refresh",
+                "RegistrationTime",
+            ),
+            -1,
+        )
         return (headers, data)
-        
+
+
 class RegistrationsComplete(_Event):
     """
     Indicates that all registrations have been listed.
-    
+
     - 'ListItems' : The number of items returned prior to this event
     """
+
     def process(self):
         """
         Translates the 'ListItems' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('ListItems',), -1)
+        generic_transforms.to_int(headers, ("ListItems",), -1)
         return (headers, data)
-        
+
+
 class Reload(_Event):
     """
     Indicates that Asterisk's configuration was reloaded.
-    
+
     - 'Message': A human-readable summary
     - 'Module': The affected module
     - 'Status': 'Enabled'
     """
-    
+
+
 class RTCPReceived(_Event):
     """
     A Real Time Control Protocol message emitted by Asterisk when using an RTP-based channel,
@@ -666,6 +795,7 @@ class RTCPReceived(_Event):
     - 'SenderSSRC': Session source
     - 'SequenceNumberCycles': ?
     """
+
     def process(self):
         """
         Translates the 'HighestSequence', 'LastSR', 'PacketsLost', 'ReceptionReports,
@@ -678,18 +808,37 @@ class RTCPReceived(_Event):
         unknown.
         """
         (headers, data) = _Event.process(self)
-        
-        _from = headers.get('From')
-        if _from and ':' in _from:
-            headers['From'] = tuple(_from.rsplit(':', 1))
+
+        _from = headers.get("From")
+        if _from and ":" in _from:
+            headers["From"] = tuple(_from.rsplit(":", 1))
         else:
-            headers['From'] = None
-            
-        generic_transforms.to_int(headers, ('HighestSequence', 'LastSR', 'PacketsLost', 'ReceptionReports', 'SequenceNumberCycles',), -1)
-        headers['DLSR'] = (headers.get('DSLR') or '').split(' ', 1)[0]
-        generic_transforms.to_float(headers, ('DLSR', 'FractionLost', 'IAJitter',), -1)
-        
+            headers["From"] = None
+
+        generic_transforms.to_int(
+            headers,
+            (
+                "HighestSequence",
+                "LastSR",
+                "PacketsLost",
+                "ReceptionReports",
+                "SequenceNumberCycles",
+            ),
+            -1,
+        )
+        headers["DLSR"] = (headers.get("DSLR") or "").split(" ", 1)[0]
+        generic_transforms.to_float(
+            headers,
+            (
+                "DLSR",
+                "FractionLost",
+                "IAJitter",
+            ),
+            -1,
+        )
+
         return (headers, data)
+
 
 class RTCPSent(_Event):
     """
@@ -709,6 +858,7 @@ class RTCPSent(_Event):
     - 'TheirLastSR': ? (int as string)
     - 'To': The IP and port of the recipient, separated by a colon
     """
+
     def process(self):
         """
         Translates the 'CumulativeLoss', 'SentOctets', 'SentPackets', 'SentRTP', and
@@ -721,35 +871,57 @@ class RTCPSent(_Event):
         unknown.
         """
         (headers, data) = _Event.process(self)
-        
-        to = headers.get('To')
-        if to and ':' in to:
-            headers['To'] = tuple(to.rsplit(':', 1))
+
+        to = headers.get("To")
+        if to and ":" in to:
+            headers["To"] = tuple(to.rsplit(":", 1))
         else:
-            headers['To'] = None
-            
-        generic_transforms.to_bool(headers, ('Result',), truth_value='Success')
-        generic_transforms.to_int(headers, ('CumulativeLoss', 'SentOctets', 'SentPackets', 'SentRTP', 'TheirLastSR',), -1)
-        headers['DLSR'] = (headers.get('DSLR') or '').split(' ', 1)[0]
-        generic_transforms.to_float(headers, ('DLSR', 'FractionLost', 'IAJitter', 'SentNTP',), -1)
-            
+            headers["To"] = None
+
+        generic_transforms.to_bool(headers, ("Result",), truth_value="Success")
+        generic_transforms.to_int(
+            headers,
+            (
+                "CumulativeLoss",
+                "SentOctets",
+                "SentPackets",
+                "SentRTP",
+                "TheirLastSR",
+            ),
+            -1,
+        )
+        headers["DLSR"] = (headers.get("DSLR") or "").split(" ", 1)[0]
+        generic_transforms.to_float(
+            headers,
+            (
+                "DLSR",
+                "FractionLost",
+                "IAJitter",
+                "SentNTP",
+            ),
+            -1,
+        )
+
         return (headers, data)
+
 
 class Shutdown(_Event):
     """
     Emitted when Asterisk shuts down.
-    
+
     - 'Restart': "True" or "False"
     - 'Shutdown': "Cleanly"
     """
+
     def process(self):
         """
         'Restart' is set to a bool.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_bool(headers, ('Restart',), truth_value='True')
+        generic_transforms.to_bool(headers, ("Restart",), truth_value="True")
         return (headers, data)
-        
+
+
 class SoftHangupRequest(_Event):
     """
     Emitted when a request to terminate the call is exchanged.
@@ -759,14 +931,15 @@ class SoftHangupRequest(_Event):
 
      - '16': ?
      - '32': ?
-     
+
     - 'Uniqueid': An Asterisk unique value
     """
-    
+
+
 class Status(_Event):
     """
     Describes the current status of a channel.
-    
+
     - 'Account': The billing account associated with the channel; may be empty
     - 'Channel': The channel being described
     - 'CallerID': The ID of the caller, ".+?" <.+?>
@@ -780,53 +953,59 @@ class Status(_Event):
     - 'State': "Up"
     - 'Uniqueid': An Asterisk unique value
     """
+
     def process(self):
         """
         Translates the 'Seconds' header's value into an int, setting it to -1 on error.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('Seconds',), -1)
+        generic_transforms.to_int(headers, ("Seconds",), -1)
         return (headers, data)
-        
+
+
 class StatusComplete(_Event):
     """
     Indicates that all requested channel information has been provided.
-    
+
     - 'Items': The number of items emitted prior to this event
     """
+
     def process(self):
         """
         Translates the 'Items' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        generic_transforms.to_int(headers, ('Items',), -1)
+        generic_transforms.to_int(headers, ("Items",), -1)
         return (headers, data)
+
 
 class UserEvent(_Event):
     r"""
     Generated in response to the UserEvent request.
-    
+
     - \*: Any key-value pairs supplied with the request, as strings
     """
+
 
 class VarSet(_Event):
     """
     Emitted when a variable is set, either globally or on a channel.
-    
+
     - 'Channel' (optional): The channel on which the variable was set, if not global
     - 'Uniqueid': An Asterisk unique value
     - 'Value': The value of the variable, as a string
     - 'Variable': The name of the variable that was set
     """
 
+
 class VoicemailUserEntry(_Event):
     """
     Describes a voicemail user.
-    
+
     - 'AttachMessage': "Yes", "No"
-	- 'AttachmentFormat': unknown
-	- 'CallOperator': "Yes", "No"
-	- 'CanReview': "Yes", "No"
+        - 'AttachmentFormat': unknown
+        - 'CallOperator': "Yes", "No"
+        - 'CanReview': "Yes", "No"
     - 'Callback': unknown
     - 'DeleteMessage': "Yes", "No"
     - 'Dialout': unknown
@@ -834,105 +1013,133 @@ class VoicemailUserEntry(_Event):
     - 'ExitContext': The context to use when leaving the mailbox
     - 'Fullname': unknown
     - 'IMAPFlags': Any associated IMAP flags (IMAP only)
-	- 'IMAPPort': The associated IMAP port (IMAP only)
-	- 'IMAPServer': The associated IMAP server (IMAP only)
-	- 'IMAPUser': The associated IMAP username (IMAP only)
-	- 'Language': The language to use for voicemail prompts
-	- 'MailCommand': unknown
-	- 'MaxMessageCount': The maximum number of messages that can be stored
-	- 'MaxMessageLength': The maximum length of any particular message
-	- 'NewMessageCount': The number of unheard messages
-	- 'OldMessageCount': The number of previously heard messages (IMAP only)
-	- 'Pager': unknown
+        - 'IMAPPort': The associated IMAP port (IMAP only)
+        - 'IMAPServer': The associated IMAP server (IMAP only)
+        - 'IMAPUser': The associated IMAP username (IMAP only)
+        - 'Language': The language to use for voicemail prompts
+        - 'MailCommand': unknown
+        - 'MaxMessageCount': The maximum number of messages that can be stored
+        - 'MaxMessageLength': The maximum length of any particular message
+        - 'NewMessageCount': The number of unheard messages
+        - 'OldMessageCount': The number of previously heard messages (IMAP only)
+        - 'Pager': unknown
     - 'SayCID': "Yes", "No"
     - 'SayDurationMinimum': The minumum amount of time a message may be
     - 'SayEnvelope': "Yes", "No"
     - 'ServerEmail': unknown
     - 'TimeZone': The timezone of the mailbox
     - 'UniqueID': unknown
-	- 'VMContext': The associated Asterisk context
-	- 'VoiceMailbox': The associated mailbox
-	- 'VolumeGain': A floating-point value
+        - 'VMContext': The associated Asterisk context
+        - 'VoiceMailbox': The associated mailbox
+        - 'VolumeGain': A floating-point value
     """
+
     def process(self):
         """
         Translates the 'MaxMessageCount', 'MaxMessageLength', 'NewMessageCount', 'OldMessageCount',
         and 'SayDurationMinimum' values into ints, setting them to -1 on error.
 
         Translates the 'VolumeGain' value into a float, setting it to None on error.
-        
+
         Translates the 'AttachMessage', 'CallOperator', 'CanReview', 'DeleteMessage', 'SayCID', and
         'SayEnvelope' values into booleans.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_bool(headers, ('AttachMessage', 'CallOperator', 'CanReview', 'DeleteMessage', 'SayCID', 'SayEnvelope',), truth_value='Yes')
-        header_list = ['MaxMessageCount', 'MaxMessageLength', 'NewMessageCount', 'SayDurationMinimum']
-        if 'OldMessageCount' in headers:
-            header_list.append('OldMessageCount')
+
+        generic_transforms.to_bool(
+            headers,
+            (
+                "AttachMessage",
+                "CallOperator",
+                "CanReview",
+                "DeleteMessage",
+                "SayCID",
+                "SayEnvelope",
+            ),
+            truth_value="Yes",
+        )
+        header_list = [
+            "MaxMessageCount",
+            "MaxMessageLength",
+            "NewMessageCount",
+            "SayDurationMinimum",
+        ]
+        if "OldMessageCount" in headers:
+            header_list.append("OldMessageCount")
         generic_transforms.to_int(headers, header_list, -1)
-        generic_transforms.to_float(headers, ('VolumeGain',), None)
-        
+        generic_transforms.to_float(headers, ("VolumeGain",), None)
+
         return (headers, data)
-    
+
+
 class VoicemailUserEntryComplete(_Event):
     """
     Indicates that all requested voicemail user definitions have been provided.
-    
+
     No, its name is not a typo; it's really "Entry" in Asterisk's code.
     """
-    
-    
-#List-aggregation events
+
+
+# List-aggregation events
 ####################################################################################################
-#These define non-Asterisk-native event-types that collect multiple events (cases where multiple
-#events are generated in response to a single action) and emit the bundle as a single message.
+# These define non-Asterisk-native event-types that collect multiple events (cases where multiple
+# events are generated in response to a single action) and emit the bundle as a single message.
+
 
 class CoreShowChannels_Aggregate(_Aggregate):
     """
     Emitted after all channels have been received in response to a CoreShowChannels request.
-    
+
     Its members consist of CoreShowChannel events.
-    
+
     It is finalised by CoreShowChannelsComplete.
     """
+
     _name = "CoreShowChannels_Aggregate"
-    
+
     _aggregation_members = (CoreShowChannel,)
     _aggregation_finalisers = (CoreShowChannelsComplete,)
-    
+
     def _finalise(self, event):
-        self._check_list_items_count(event, 'ListItems')
+        self._check_list_items_count(event, "ListItems")
         return _Aggregate._finalise(self, event)
-        
+
+
 class ParkedCalls_Aggregate(_Aggregate):
     """
     Emitted after all parked calls have been received in response to a ParkedCalls request.
-    
+
     Its members consist of ParkedCall events.
-    
+
     It is finalised by ParkedCallsComplete.
     """
+
     _name = "ParkedCalls_Aggregate"
-    
+
     _aggregation_members = (ParkedCall,)
     _aggregation_finalisers = (ParkedCallsComplete,)
-    
+
     def _finalise(self, event):
-        self._check_list_items_count(event, 'Total')
+        self._check_list_items_count(event, "Total")
         return _Aggregate._finalise(self, event)
-        
+
+
 class QueueStatus_Aggregate(_Aggregate):
     """
     Emitted after all queue properties have been received in response to a QueueStatus request.
-    
+
     Its members consist of QueueParams, QueueMember, and QueueEntry events.
-    
+
     It is finalised by QueueStatusComplete.
     """
+
     _name = "QueueStatus_Aggregate"
-    
-    _aggregation_members = (QueueParams, QueueMember, QueueEntry,)
+
+    _aggregation_members = (
+        QueueParams,
+        QueueMember,
+        QueueEntry,
+    )
     _aggregation_finalisers = (QueueStatusComplete,)
 
 
@@ -944,74 +1151,81 @@ class QueueSummary_Aggregate(_Aggregate):
 
     It is finalised by QueueSummaryComplete.
     """
+
     _name = "QueueSummary_Aggregate"
 
     _aggregation_members = (QueueSummary,)
     _aggregation_finalisers = (QueueSummaryComplete,)
-	
+
 
 class SIPpeers_Aggregate(_Aggregate):
     """
     Emitted after all queue properties have been received in response to a SIPpeers request.
 
     Its members consist of 'PeerEntry' events.
-    
+
     It is finalised by PeerlistComplete.
     """
+
     _name = "SIPpeers_Aggregate"
-    
+
     _aggregation_members = (PeerEntry,)
     _aggregation_finalisers = (PeerlistComplete,)
-    
+
     def _finalise(self, event):
-        self._check_list_items_count(event, 'ListItems')
+        self._check_list_items_count(event, "ListItems")
         return _Aggregate._finalise(self, event)
-        
+
+
 class SIPshowregistry_Aggregate(_Aggregate):
     """
     Emitted after all SIP registrants have been received in response to a SIPshowregistry request.
-    
+
     Its members consist of RegistryEntry events.
-    
+
     It is finalised by RegistrationsComplete.
     """
+
     _name = "SIPshowregistry_Aggregate"
-    
+
     _aggregation_members = (RegistryEntry,)
     _aggregation_finalisers = (RegistrationsComplete,)
-    
+
     def _finalise(self, event):
-        self._check_list_items_count(event, 'ListItems')
+        self._check_list_items_count(event, "ListItems")
         return _Aggregate._finalise(self, event)
-        
+
+
 class Status_Aggregate(_Aggregate):
     """
     Emitted after all statuses have been received in response to a Status request.
-    
+
     Its members consist of Status events.
-    
+
     It is finalised by StatusComplete.
     """
+
     _name = "Status_Aggregate"
-    
+
     _aggregation_members = (Status,)
     _aggregation_finalisers = (StatusComplete,)
-    
+
     def _finalise(self, event):
-        self._check_list_items_count(event, 'Items')
+        self._check_list_items_count(event, "Items")
         return _Aggregate._finalise(self, event)
-        
+
+
 class VoicemailUsersList_Aggregate(_Aggregate):
     """
     Emitted after all voicemail users have been received in response to a VoicemailUsersList
     request.
-    
+
     Its members consist of VoicemailUserEntry events.
-    
+
     It is finalised by VoicemailUserEntryComplete.
     """
+
     _name = "VoicemailUsersList_Aggregate"
-    
+
     _aggregation_members = (VoicemailUserEntry,)
     _aggregation_finalisers = (VoicemailUserEntryComplete,)
-    

--- a/pystrix/ami/dahdi.py
+++ b/pystrix/ami/dahdi.py
@@ -5,7 +5,7 @@ pystrix.ami.dahdi
 Provides classes meant to be fed to a `Manager` instance's `send_action()` function.
 
 Specifically, this module provides implementations for features specific to the DAHDI technology.
- 
+
 Legal
 -----
 
@@ -33,72 +33,84 @@ Authors:
 The requests implemented by this module follow the definitions provided by
 https://wiki.asterisk.org/
 """
-from pystrix.ami.ami import (_Request)
+
 from pystrix.ami import dahdi_events
+from pystrix.ami.ami import _Request
+
 
 class DAHDIDNDoff(_Request):
     """
     Sets a DAHDI channel's DND status to off.
     """
+
     def __init__(self, dahdi_channel):
         """
         `dahdi_channel` is the channel to modify.
         """
-        _Request.__init__(self, 'DAHDIDNDoff')
-        self['DAHDIChannel'] = dahdi_channel
+        _Request.__init__(self, "DAHDIDNDoff")
+        self["DAHDIChannel"] = dahdi_channel
+
 
 class DAHDIDNDon(_Request):
     """
     Sets a DAHDI channel's DND status to on.
     """
+
     def __init__(self, dahdi_channel):
         """
         `dahdi_channel` is the channel to modify.
         """
-        _Request.__init__(self, 'DAHDIDNDon')
-        self['DAHDIChannel'] = dahdi_channel
-        
+        _Request.__init__(self, "DAHDIDNDon")
+        self["DAHDIChannel"] = dahdi_channel
+
+
 class DAHDIDialOffhook(_Request):
     """
     Dials a number on an off-hook DAHDI channel.
     """
+
     def __init__(self, dahdi_channel, number):
         """
         `dahdi_channel` is the channel to use and `number` is the number to dial.
         """
-        _Request.__init__(self, 'DAHDIDialOffhook')
-        self['DAHDIChannel'] = dahdi_channel
-        self['Number'] = number
+        _Request.__init__(self, "DAHDIDialOffhook")
+        self["DAHDIChannel"] = dahdi_channel
+        self["Number"] = number
+
 
 class DAHDIHangup(_Request):
     """
     Hangs up a DAHDI channel.
     """
+
     def __init__(self, dahdi_channel):
         """
         `dahdi_channel` is the channel to hang up.
         """
-        _Request.__init__(self, 'DAHDIHangup')
-        self['DAHDIChannel'] = dahdi_channel
+        _Request.__init__(self, "DAHDIHangup")
+        self["DAHDIChannel"] = dahdi_channel
+
 
 class DAHDIRestart(_Request):
     """
     Fully restarts all DAHDI channels.
     """
+
     def __init__(self):
-        _Request.__init__(self, 'DAHDIRestart')
+        _Request.__init__(self, "DAHDIRestart")
+
 
 class DAHDIShowChannels(_Request):
     """
     Provides the current status of all (or one) DAHDI channels through a series of
     'DAHDIShowChannels' events, ending with a 'DAHDIShowChannelsComplete' event.
     """
+
     _aggregates = (dahdi_events.DAHDIShowChannels_Aggregate,)
     _synchronous_events_list = (dahdi_events.DAHDIShowChannels,)
     _synchronous_events_finalising = (dahdi_events.DAHDIShowChannelsComplete,)
-    
+
     def __init__(self, dahdi_channel=None):
-        _Request.__init__(self, 'DAHDIShowChannels')
+        _Request.__init__(self, "DAHDIShowChannels")
         if dahdi_channel is not None:
-            self['DAHDIChannel'] = dahdi_channel
-            
+            self["DAHDIChannel"] = dahdi_channel

--- a/pystrix/ami/dahdi_events.py
+++ b/pystrix/ami/dahdi_events.py
@@ -31,15 +31,17 @@ Authors:
 The events implemented by this module follow the definitions provided by
 http://www.asteriskdocs.org/ and https://wiki.asterisk.org/
 """
-from pystrix.ami.ami import (_Aggregate, _Event)
+
 from pystrix.ami import generic_transforms
+from pystrix.ami.ami import _Aggregate, _Event
+
 
 class DAHDIShowChannels(_Event):
     """
     Describes the current state of a DAHDI channel.
-    
+
     Yes, the event's name is pluralised.
-    
+
     - 'AccountCode': unknown (not present if the DAHDI channel is down)
     - 'Alarm': unknown
     - 'Channel': The channel being described (not present if the DAHDI channel is down)
@@ -51,57 +53,68 @@ class DAHDIShowChannels(_Event):
     - 'SignallingCode': A numeric description of the current signalling state
     - 'Uniqueid': unknown (not present if the DAHDI channel is down)
     """
+
     def process(self):
         """
         Translates the 'DND' header's value into a bool.
-        
+
         Translates the 'DAHDIChannel' and 'SignallingCode' headers' values into ints, or -1 on
         failure.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_bool(headers, ('DND',), truth_value='Enabled')
-        generic_transforms.to_int(headers, ('DAHDIChannel', 'SignallingCode',), -1)
-                
+
+        generic_transforms.to_bool(headers, ("DND",), truth_value="Enabled")
+        generic_transforms.to_int(
+            headers,
+            (
+                "DAHDIChannel",
+                "SignallingCode",
+            ),
+            -1,
+        )
+
         return (headers, data)
+
 
 class DAHDIShowChannelsComplete(_Event):
     """
     Indicates that all DAHDI channels have been described.
-    
+
     - 'Items': The number of items returned prior to this event
     """
+
     def process(self):
         """
         Translates the 'Items' header's value into an int, or -1 on failure.
         """
         (headers, data) = _Event.process(self)
-        
-        generic_transforms.to_int(headers, ('Items',), -1)
-        
+
+        generic_transforms.to_int(headers, ("Items",), -1)
+
         return (headers, data)
-        
-        
-#List-aggregation events
+
+
+# List-aggregation events
 ####################################################################################################
-#These define non-Asterisk-native event-types that collect multiple events (cases where multiple
-#events are generated in response to a single action) and emit the bundle as a single message.
+# These define non-Asterisk-native event-types that collect multiple events (cases where multiple
+# events are generated in response to a single action) and emit the bundle as a single message.
+
 
 class DAHDIShowChannels_Aggregate(_Aggregate):
     """
     Emitted after all DAHDI channels have been enumerated in response to a DAHDIShowChannels
     request.
-    
+
     Its members consist of DAHDIShowChannels events.
-    
+
     It is finalised by DAHDIShowChannelsComplete.
     """
+
     _name = "DAHDIShowChannels_Aggregate"
-    
+
     _aggregation_members = (DAHDIShowChannels,)
     _aggregation_finalisers = (DAHDIShowChannelsComplete,)
-    
+
     def _finalise(self, event):
-        self._check_list_items_count(event, 'Items')
+        self._check_list_items_count(event, "Items")
         return _Aggregate._finalise(self, event)
-        

--- a/pystrix/ami/generic_transforms.py
+++ b/pystrix/ami/generic_transforms.py
@@ -28,10 +28,17 @@ Authors:
 
 - Neil Tallim <flan@uguu.ca>
 """
+
 string_type = str
 
 
-def to_bool(dictionary, keys, truth_value=None, truth_function=(lambda x:bool(x)), preprocess=(lambda x:x)):
+def to_bool(
+    dictionary,
+    keys,
+    truth_value=None,
+    truth_function=(lambda x: bool(x)),
+    preprocess=(lambda x: x),
+):
     for key in keys:
         if truth_value:
             dictionary[key] = dictionary.get(key) == truth_value
@@ -42,7 +49,7 @@ def to_bool(dictionary, keys, truth_value=None, truth_function=(lambda x:bool(x)
                 dictionary[key] = False
 
 
-def to_float(dictionary, keys, failure_value, preprocess=(lambda x:x)):
+def to_float(dictionary, keys, failure_value, preprocess=(lambda x: x)):
     for key in keys:
         try:
             dictionary[key] = float(preprocess(dictionary.get(key)))
@@ -50,7 +57,7 @@ def to_float(dictionary, keys, failure_value, preprocess=(lambda x:x)):
             dictionary[key] = failure_value
 
 
-def to_int(dictionary, keys, failure_value, preprocess=(lambda x:x)):
+def to_int(dictionary, keys, failure_value, preprocess=(lambda x: x)):
     for key in keys:
         try:
             dictionary[key] = int(preprocess(dictionary.get(key)))
@@ -60,7 +67,7 @@ def to_int(dictionary, keys, failure_value, preprocess=(lambda x:x)):
 
 def add_result(dictionary, key, result_map):
     if dictionary[key] in result_map:
-        dictionary['Result'] = result_map[dictionary[key]]
+        dictionary["Result"] = result_map[dictionary[key]]
 
 
 def string_to_bytes(value, encoding="utf-8", errors="strict"):

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,15 +1,14 @@
-# Lint configuration for pystrix.
+# Lint and format configuration for pystrix.
 #
-# Formatting is intentionally not enabled yet (see issue #45): the existing
-# style is non-standard and `ruff format` would rewrite ~4,000 lines. A later
-# pass, paired with the Python 2 shim removal, will own formatting. When the
-# project moves to pyproject.toml, this config can move there.
+# Formatting is handled by `ruff format` at its default line length of 88.
+# When the project moves to pyproject.toml, this config can move there.
 target-version = "py39"
 
 [lint]
-# pycodestyle errors/warnings and pyflakes, minus the whitespace, indentation,
-# and line-length families that a formatting pass will own.
-select = ["E4", "E7", "E9", "F", "W605"]
+# pycodestyle errors, pyflakes, import sorting (isort), and invalid escape
+# sequences. The whitespace, indentation, and line-length families are owned by
+# `ruff format`.
+select = ["E4", "E7", "E9", "F", "I", "W605"]
 
 [lint.per-file-ignores]
 # The __init__ modules deliberately re-export their public API.

--- a/setup.py
+++ b/setup.py
@@ -3,50 +3,50 @@
 Deployment script for pystrix.
 """
 
-from pystrix import VERSION
-
-from setuptools import setup
 import os
 
+from setuptools import setup
+
+from pystrix import VERSION
 
 CLASSIFIERS = [
-    'Intended Audience :: Developers',
-    'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
-    'Programming Language :: Python :: 3.12',
-    'Programming Language :: Python :: 3.13',
-    'Topic :: Communications :: Telephony'
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Communications :: Telephony",
 ]
 
-README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
+README = open(os.path.join(os.path.dirname(__file__), "README.md")).read()
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
-    author='Marta Solano',
-    author_email='marta.solano@ivrtechnology.com',
-    name='pystrix',
+    author="Marta Solano",
+    author_email="marta.solano@ivrtechnology.com",
+    name="pystrix",
     version=VERSION,
-    description='Python bindings for Asterisk Manager Interface and Asterisk Gateway Interface',
+    description="Python bindings for Asterisk Manager Interface and Asterisk Gateway Interface",
     long_description=README,
-    long_description_content_type='text/markdown',
-    url='https://github.com/IVRTech/pystrix',
-    license='GNU Lesser General Public License v3 or later',
-    platforms=['OS Independent'],
+    long_description_content_type="text/markdown",
+    url="https://github.com/IVRTech/pystrix",
+    license="GNU Lesser General Public License v3 or later",
+    platforms=["OS Independent"],
     classifiers=CLASSIFIERS,
-    python_requires='>=3.9',
+    python_requires=">=3.9",
     extras_require={
-        'test': ['pytest', 'pytest-cov'],
+        "test": ["pytest", "pytest-cov"],
     },
     packages=[
-     'pystrix',
-     'pystrix.agi',
-     'pystrix.ami',
-    ]
+        "pystrix",
+        "pystrix.agi",
+        "pystrix.ami",
+    ],
 )

--- a/tests/test_agi_core.py
+++ b/tests/test_agi_core.py
@@ -1,10 +1,17 @@
 """Tests for AGI response parsing and helpers (`pystrix.agi.agi_core`)."""
+
 import pytest
 
 from pystrix.agi.agi_core import (
-    _AGI, _Action, quote,
-    AGIInvalidCommandError, AGIDeadChannelError, AGIResultHangup, AGINoResultError,
-    AGIUsageError, AGIUnknownError,
+    _AGI,
+    AGIDeadChannelError,
+    AGIInvalidCommandError,
+    AGINoResultError,
+    AGIResultHangup,
+    AGIUnknownError,
+    AGIUsageError,
+    _Action,
+    quote,
 )
 
 
@@ -17,7 +24,7 @@ class _FakeReader:
 
     def readline(self):
         if self._index >= len(self._lines):
-            return b''
+            return b""
         line = self._lines[self._index]
         self._index += 1
         return line
@@ -32,21 +39,21 @@ def _agi(*lines):
 
 
 def test_parses_success_result():
-    response = _agi('200 result=1\n')._get_result()
+    response = _agi("200 result=1\n")._get_result()
     assert response.code == 200
-    assert response.items['result'].value == '1'
+    assert response.items["result"].value == "1"
 
 
 def test_parses_result_data():
-    response = _agi('200 result=1 (speech)\n')._get_result()
-    assert response.items['result'].value == '1'
-    assert response.items['result'].data == 'speech'
+    response = _agi("200 result=1 (speech)\n")._get_result()
+    assert response.items["result"].value == "1"
+    assert response.items["result"].data == "speech"
 
 
 def test_result_without_parenthetical_has_empty_data():
     # A result with no parenthetical reports data as '' (empty string), not None.
-    response = _agi('200 result=1\n')._get_result()
-    assert response.items['result'].data == ''
+    response = _agi("200 result=1\n")._get_result()
+    assert response.items["result"].data == ""
 
 
 def test_usage_error_collects_multiline_block():
@@ -54,66 +61,66 @@ def test_usage_error_collects_multiline_block():
     # the accumulated block.
     with pytest.raises(AGIUsageError) as exc_info:
         _agi(
-            '520 Invalid command syntax.\n',
-            'Usage: ANSWER\n',
-            '520 End of proper usage.\n',
+            "520 Invalid command syntax.\n",
+            "Usage: ANSWER\n",
+            "520 End of proper usage.\n",
         )._get_result()
     message = str(exc_info.value)
-    assert '520 Invalid command syntax.' in message
-    assert 'Usage: ANSWER' in message
+    assert "520 Invalid command syntax." in message
+    assert "Usage: ANSWER" in message
 
 
 def test_unrecognized_code_returns_none():
     # A line with no leading status code (for example after a signal) yields no
     # result rather than raising.
-    assert _agi('\n')._get_result() is None
+    assert _agi("\n")._get_result() is None
 
 
 def test_unknown_code_raises():
     with pytest.raises(AGIUnknownError):
-        _agi('418 unexpected\n')._get_result()
+        _agi("418 unexpected\n")._get_result()
 
 
 def test_hangup_detected_by_data_not_value():
     # The hangup guard keys on the parenthetical data, not the result value, so a
     # non-(-1) value with 'hangup' data must still raise.
     with pytest.raises(AGIResultHangup):
-        _agi('200 result=0 (hangup)\n')._get_result()
+        _agi("200 result=0 (hangup)\n")._get_result()
 
 
 def test_hangup_not_raised_when_check_disabled():
-    response = _agi('200 result=-1 (hangup)\n')._get_result(check_hangup=False)
-    assert response.items['result'].data == 'hangup'
+    response = _agi("200 result=-1 (hangup)\n")._get_result(check_hangup=False)
+    assert response.items["result"].data == "hangup"
 
 
 def test_invalid_command_raises():
     with pytest.raises(AGIInvalidCommandError):
-        _agi('510 Invalid or unknown command\n')._get_result()
+        _agi("510 Invalid or unknown command\n")._get_result()
 
 
 def test_dead_channel_raises():
     with pytest.raises(AGIDeadChannelError):
-        _agi('511 Command Not Permitted on a dead channel\n')._get_result()
+        _agi("511 Command Not Permitted on a dead channel\n")._get_result()
 
 
 def test_missing_result_key_raises():
     with pytest.raises(AGINoResultError):
-        _agi('200 foo=bar\n')._get_result()
+        _agi("200 foo=bar\n")._get_result()
 
 
 def test_hangup_result_raises():
     with pytest.raises(AGIResultHangup):
-        _agi('200 result=-1 (hangup)\n')._get_result()
+        _agi("200 result=-1 (hangup)\n")._get_result()
 
 
 def test_action_command_formatting():
-    assert _Action('ANSWER').command == 'ANSWER\n'
+    assert _Action("ANSWER").command == "ANSWER\n"
     # None arguments are dropped and a trailing newline is always present.
-    assert _Action('STREAM FILE', 'demo', None, '#').command == 'STREAM FILE demo #\n'
+    assert _Action("STREAM FILE", "demo", None, "#").command == "STREAM FILE demo #\n"
 
 
 def test_quote_wraps_in_double_quotes():
-    assert quote('demo') == '"demo"'
+    assert quote("demo") == '"demo"'
     assert quote(5) == '"5"'
 
 
@@ -126,7 +133,7 @@ class _StrReader:
 
     def readline(self):
         if self._index >= len(self._lines):
-            return ''
+            return ""
         line = self._lines[self._index]
         self._index += 1
         return line
@@ -141,15 +148,15 @@ def _agi_with_reader(reader):
 
 def test_str_input_is_read_without_decoding():
     # Plain AGI reads str from stdin; _read_line must not choke trying to decode it.
-    response = _agi_with_reader(_StrReader('200 result=1\n'))._get_result()
-    assert response.items['result'].value == '1'
+    response = _agi_with_reader(_StrReader("200 result=1\n"))._get_result()
+    assert response.items["result"].value == "1"
 
 
 def test_malformed_bytes_surface_a_decode_error():
     # A real decode failure on socket bytes propagates instead of being swallowed.
     class _BadBytesReader:
         def readline(self):
-            return b'\xff\xfe not utf-8\n'
+            return b"\xff\xfe not utf-8\n"
 
     with pytest.raises(UnicodeDecodeError):
         _agi_with_reader(_BadBytesReader())._get_result()

--- a/tests/test_ami_message.py
+++ b/tests/test_ami_message.py
@@ -1,68 +1,69 @@
 """Tests for AMI message parsing (`pystrix.ami.ami._Message`)."""
-from pystrix.ami.ami import _Message, RESPONSE_GENERIC, EVENT_GENERIC
+
+from pystrix.ami.ami import EVENT_GENERIC, RESPONSE_GENERIC, _Message
 
 
 def _message(*lines):
     # Asterisk sends CRLF-terminated lines, which `read_message` collects into a
     # list before constructing a `_Message`. Reproduce that here.
-    return _Message([line + '\r\n' for line in lines])
+    return _Message([line + "\r\n" for line in lines])
 
 
 def test_parses_headers():
-    message = _message('Response: Success', 'ActionID: abc-1')
-    assert message['Response'] == 'Success'
-    assert message['ActionID'] == 'abc-1'
-    assert message.action_id == 'abc-1'
+    message = _message("Response: Success", "ActionID: abc-1")
+    assert message["Response"] == "Success"
+    assert message["ActionID"] == "abc-1"
+    assert message.action_id == "abc-1"
 
 
 def test_name_prefers_event_then_response():
-    assert _message('Event: Hangup', 'ActionID: 1').name == 'Hangup'
-    assert _message('Response: Success').name == 'Success'
+    assert _message("Event: Hangup", "ActionID: 1").name == "Hangup"
+    assert _message("Response: Success").name == "Success"
 
 
 def test_name_prefers_event_when_both_present():
     # `name` is Event or Response, so Event wins when a message carries both.
-    assert _message('Event: Hangup', 'Response: Success').name == 'Hangup'
+    assert _message("Event: Hangup", "Response: Success").name == "Hangup"
 
 
 def test_equality_against_string_uses_name():
-    assert _message('Event: Hangup') == 'Hangup'
+    assert _message("Event: Hangup") == "Hangup"
 
 
 def test_data_payload_follows_headers():
-    message = _message('Response: Follows', 'raw output line without a colon')
-    assert message['Response'] == 'Follows'
-    assert message.data == ['raw output line without a colon']
+    message = _message("Response: Follows", "raw output line without a colon")
+    assert message["Response"] == "Follows"
+    assert message.data == ["raw output line without a colon"]
 
 
 def test_data_mode_is_sticky_for_later_colon_lines():
     # Once a data line is seen, later colon-bearing lines stay data and are not
     # parsed as headers.
-    message = _message('Response: Follows', 'first data line', 'Looks: like-a-header')
-    assert message['Response'] == 'Follows'
-    assert message.data == ['first data line', 'Looks: like-a-header']
-    assert 'Looks' not in message
+    message = _message("Response: Follows", "first data line", "Looks: like-a-header")
+    assert message["Response"] == "Follows"
+    assert message.data == ["first data line", "Looks: like-a-header"]
+    assert "Looks" not in message
 
 
 def test_fake_eol_line_starts_data_section():
     # A line ending in the fake-EOL pattern marks the start of the data section.
-    message = _Message(['Response: Follows\r\n', 'payload\n\r\n'])
-    assert message['Response'] == 'Follows'
-    assert message.data == ['payload']
+    message = _Message(["Response: Follows\r\n", "payload\n\r\n"])
+    assert message["Response"] == "Follows"
+    assert message.data == ["payload"]
 
 
 def test_non_crlf_line_starts_data_section():
     # A line not terminated by CRLF is treated as data, not a header.
-    message = _Message(['Response: Follows\r\n', 'payload\n'])
-    assert message['Response'] == 'Follows'
-    assert message.data == ['payload']
+    message = _Message(["Response: Follows\r\n", "payload\n"])
+    assert message["Response"] == "Follows"
+    assert message.data == ["payload"]
 
 
 def test_generic_response_when_only_action_id():
     # A reply with an ActionID but no Response header is salvaged as generic.
-    assert _message('ActionID: 7')['Response'] == RESPONSE_GENERIC
+    assert _message("ActionID: 7")["Response"] == RESPONSE_GENERIC
 
 
 def test_generic_event_when_unsolicited():
     # A message with neither Response, Event, nor ActionID is a generic event.
-    assert _message('Foo: bar')['Event'] == EVENT_GENERIC
+    assert _message("Foo: bar")["Event"] == EVENT_GENERIC

--- a/tests/test_ami_request.py
+++ b/tests/test_ami_request.py
@@ -1,75 +1,76 @@
 """Tests for AMI request building (`pystrix.ami.ami._Request`)."""
+
 from pystrix.ami.ami import _Request
 
 
 def _build(request, action_id=None, **kwargs):
-    return request.build_request(action_id, lambda: 'GEN-1', **kwargs)
+    return request.build_request(action_id, lambda: "GEN-1", **kwargs)
 
 
 def test_generates_action_id_when_absent():
-    command, action_id = _build(_Request('Ping'))
-    assert action_id == 'GEN-1'
-    assert command == 'Action: Ping\r\nActionID: GEN-1\r\n\r\n'
+    command, action_id = _build(_Request("Ping"))
+    assert action_id == "GEN-1"
+    assert command == "Action: Ping\r\nActionID: GEN-1\r\n\r\n"
 
 
 def test_uses_explicit_action_id():
-    command, action_id = _build(_Request('Ping'), action_id='custom')
-    assert action_id == 'custom'
-    assert 'ActionID: custom' in command
+    command, action_id = _build(_Request("Ping"), action_id="custom")
+    assert action_id == "custom"
+    assert "ActionID: custom" in command
 
 
 def test_action_is_always_the_first_line():
-    request = _Request('Login')
-    request['Username'] = 'admin'
+    request = _Request("Login")
+    request["Username"] = "admin"
     command, _ = _build(request)
-    assert command.startswith('Action: Login\r\n')
+    assert command.startswith("Action: Login\r\n")
 
 
 def test_multi_value_header_expands_to_repeated_lines():
-    request = _Request('Originate')
-    request['Variable'] = ('a=1', 'b=2')
+    request = _Request("Originate")
+    request["Variable"] = ("a=1", "b=2")
     command, _ = _build(request)
-    assert 'Variable: a=1\r\n' in command
-    assert 'Variable: b=2\r\n' in command
+    assert "Variable: a=1\r\n" in command
+    assert "Variable: b=2\r\n" in command
 
 
 def test_multi_value_order_preserved_and_blank_line_terminator():
-    request = _Request('Originate')
-    request['Variable'] = ('a=1', 'b=2')
+    request = _Request("Originate")
+    request["Variable"] = ("a=1", "b=2")
     command, _ = _build(request)
-    assert command.index('Variable: a=1') < command.index('Variable: b=2')
-    assert command.endswith('\r\n\r\n')
+    assert command.index("Variable: a=1") < command.index("Variable: b=2")
+    assert command.endswith("\r\n\r\n")
 
 
 def test_kwargs_become_headers():
-    command, _ = _build(_Request('Ping'), Extra='x')
-    assert 'Extra: x' in command
+    command, _ = _build(_Request("Ping"), Extra="x")
+    assert "Extra: x" in command
 
 
 # build_request resolves the ActionID with the precedence documented on the
 # method: an explicit argument wins, then a value already set on the request,
 # then a generated one (fixed in #43).
 def test_preset_action_id_used_when_none_passed():
-    request = _Request('Ping')
-    request['ActionID'] = 'preset'
+    request = _Request("Ping")
+    request["ActionID"] = "preset"
     command, action_id = _build(request)
-    assert action_id == 'preset'
-    assert 'ActionID: preset' in command
+    assert action_id == "preset"
+    assert "ActionID: preset" in command
 
 
 def test_explicit_action_id_wins_over_preset():
-    request = _Request('Ping')
-    request['ActionID'] = 'preset'
-    command, action_id = _build(request, action_id='explicit')
-    assert action_id == 'explicit'
-    assert 'ActionID: explicit' in command
+    request = _Request("Ping")
+    request["ActionID"] = "preset"
+    command, action_id = _build(request, action_id="explicit")
+    assert action_id == "explicit"
+    assert "ActionID: explicit" in command
 
 
 def test_non_string_action_id_is_stringified():
     # A non-string ActionID must be returned as a string so it matches the
     # string-keyed responses Asterisk sends back (see #43 review).
-    request = _Request('Ping')
-    request['ActionID'] = 7
+    request = _Request("Ping")
+    request["ActionID"] = 7
     command, action_id = _build(request)
-    assert action_id == '7'
-    assert 'ActionID: 7' in command
+    assert action_id == "7"
+    assert "ActionID: 7" in command

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -3,16 +3,21 @@
 
 def test_package_imports():
     import pystrix
+
     assert pystrix.VERSION
 
 
 def test_public_entry_points_import():
-    from pystrix.agi import AGI, FastAGIServer, FastAGI
-    from pystrix.ami import Manager
+    from pystrix.agi import AGI, FastAGI, FastAGIServer
     from pystrix.agi.fastagi import FastAGIServer as _FastAGIServer
+    from pystrix.ami import Manager
 
     # The re-export must be the same class object, and importing fastagi
     # exercises the code path that has to stay free of the cgi module removed in
     # Python 3.13.
     assert FastAGIServer is _FastAGIServer
-    assert isinstance(AGI, type) and isinstance(FastAGI, type) and isinstance(Manager, type)
+    assert (
+        isinstance(AGI, type)
+        and isinstance(FastAGI, type)
+        and isinstance(Manager, type)
+    )


### PR DESCRIPTION
Closes #52

## Summary

The deferred `ruff format` pass, now that the Python 2 shim removal (#47) cleared pending code churn. Line length 88, with import sorting (ruff's `I` rule) bundled in. Both are now enforced in pre-commit and CI.

## Commit structure

Deliberately three commits so `git blame` survives the reformat:
1. **Config** — add the `I` rule to `ruff.toml`, a `ruff-format` pre-commit hook, a `ruff format --check` CI step, and update the README/changelog.
2. **Reformat** — pure mechanical `ruff format` + import sort across 24 files (~2,560/1,649). No behavior change.
3. **`.git-blame-ignore-revs`** — lists commit 2 so `git blame` and GitHub attribute lines to their real authors. Enable locally with `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

## One non-mechanical detail

The reformat wrapped the legacy `type(reload) == bool` statement in `core.py`, which separated its `# noqa: E721` from the comparison. The noqa was moved onto the comparison line. The `and/or` logic is unchanged.

## Verification
- `ruff format --check .` and `ruff check .` both pass; the format is idempotent.
- Package imports cleanly; 37 tests pass.
- The package now has a single remaining `noqa` (the E721 above); everything else is clean.

## Follow-up
- Migrate packaging to `pyproject.toml` with an SPDX license expression (the ruff config can move there).
- Cut the 1.3.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
