### PR TITLE
Release 1.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ The core split to keep in mind: AGI is one blocking call per script; AMI is one 
 
 ```
 pystrix/
-├── __init__.py             VERSION lives here (currently 1.2.0)
+├── __init__.py             VERSION lives here (single source of truth)
 ├── ami/
 │   ├── ami.py              Manager class + threading/socket core (the heart of AMI)
 │   ├── core.py             ~60 Action classes (Login, Originate, Hangup, Ping, ...)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Migrated packaging from `setup.py` to `pyproject.toml` (PEP 621) with a PEP 639 SPDX license expression (`LGPL-3.0-or-later`). Moved the ruff config into `[tool.ruff]`, and removed `setup.py`, `build-release.py`, and `ruff.toml`. Build with `python -m build`; the version is read dynamically from `pystrix.VERSION`.
 
 ### Removed
-- The Python 2 compatibility shims: the `queue` and `socketserver` import fallbacks, the `basestring` branch in `generic_transforms`, and the explicit `(object)` base classes. The codebase is now Python 3 only.
+- The Python 2 compatibility shims: the `queue` and `socketserver` import fallbacks, the `basestring` branch in `generic_transforms`, and the explicit `(object)` base classes. The codebase is now Python 3 only. Dropping Python 2 is released as a pragmatic minor bump rather than a major one, since Python 2 support was already nominal and end-of-life.
 
 ### Fixed
 - Narrowed the bare `except` around `line.decode()` in `_AGI._read_line` to an `isinstance(line, bytes)` check. A real `UnicodeDecodeError` on malformed socket bytes now surfaces instead of being swallowed and leaving raw bytes in the line (#50).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-24
+
 ### Added
 - `AGENTS.md` with an architecture overview and contributor guidance.
 - `CLAUDE.md` pointing to `AGENTS.md`.
@@ -51,5 +53,6 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Releases before 1.2.0 are recorded in the git commit history.
 
-[Unreleased]: https://github.com/IVRTech/pystrix/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/IVRTech/pystrix/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/IVRTech/pystrix/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/IVRTech/pystrix/releases/tag/v1.2.0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository is version **1.3.0**. The canonical version lives in `pystrix/__
 
 | pystrix | Python |
 | --- | --- |
-| 1.3.0 and later | 3.9 – 3.13 |
+| 1.3.x | 3.9 – 3.13 |
 | 1.2.0 and earlier | 2.7, 3.4+ (legacy, unmaintained) |
 
 From 1.3.0 on, the `requires-python` metadata makes pip resolve automatically: a project on an older Python receives 1.2.x. All versions target Asterisk 1.10+.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ pystrix runs on Python 3.9+. It targets Asterisk 1.10+ and provides a rich, easy
 
 The package is a toolkit, not a framework. You can drop it into a larger project without adopting an async framework such as Twisted.
 
-This repository is version **1.2.0**. The canonical version lives in `pystrix/__init__.py`. New releases follow `<major>.<minor>.<patch>`, with a patch release cut for each bug fix.
+This repository is version **1.3.0**. The canonical version lives in `pystrix/__init__.py`. New releases follow `<major>.<minor>.<patch>`, with a patch release cut for each bug fix.
+
+## Compatibility
+
+| pystrix | Python |
+| --- | --- |
+| 1.3.0 and later | 3.9 – 3.13 |
+| 1.2.0 and earlier | 2.7, 3.4+ (legacy, unmaintained) |
+
+From 1.3.0 on, the `requires-python` metadata makes pip resolve automatically: a project on an older Python receives 1.2.x. All versions target Asterisk 1.10+.
 
 ## Installation
 

--- a/pystrix/__init__.py
+++ b/pystrix/__init__.py
@@ -43,5 +43,5 @@ Authors:
 import pystrix.agi
 import pystrix.ami
 
-VERSION = "1.2.0"
+VERSION = "1.3.0"
 COPYRIGHT = "2013, Neil Tallim <flan@uguu.ca>"


### PR DESCRIPTION
Closes #56

## Summary

Prepares the **1.3.0** release — the first after the modernization pass. It bundles the full `[Unreleased]` changelog into a dated `[1.3.0]` section.

## Changes
- Bump `VERSION` to `1.3.0` in `pystrix/__init__.py` (the build reads it dynamically).
- Move the changelog `[Unreleased]` entries to `## [1.3.0] - 2026-06-24`; add a fresh empty `[Unreleased]`; update the reference links (`[1.3.0]` compares v1.2.0...v1.3.0, `[Unreleased]` compares v1.3.0...HEAD).
- Add a **Compatibility** matrix to the README (pystrix version to Python), with a note that `requires-python` makes pip auto-resolve older Pythons to 1.2.x.

## What 1.3.0 contains (highlights)
Python 3-only (Py2 shims removed), `pyproject.toml` packaging with an SPDX license, a pytest suite + coverage, ruff lint + format, CI across Python 3.9-3.13 with a package-build gate, the FastAGI cgi/3.13 fix, and the `build_request` ActionID fix. Full detail in the changelog `[1.3.0]` section.

## Versioning note
Dropping Python 2 is strictly a breaking change (→ 2.0.0), but Py2 support was already nominal and end-of-life, so **1.3.0** (minor) is the pragmatic, defensible choice.

## After merge
Tag `v1.3.0` on the merge commit and publish a GitHub release with the 1.3.0 changelog notes.

## Verification
- `python -m build` produces `pystrix-1.3.0` sdist + wheel.
- `ruff check .`, `ruff format --check .`, and 37 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
