### PR TITLE
Auto-publish to PyPI on release (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: Publish to PyPI
 
 # Publishes to PyPI when a GitHub release is published. Authentication uses
 # PyPI Trusted Publishing (OIDC), so no API token is stored in the repo or CI.
+# Build and publish are separate jobs: only the publish job holds the OIDC
+# publishing identity, so the build backend never has access to it.
 #
 # One-time PyPI setup (maintainer): add a Trusted Publisher to the pystrix
 # project with owner "IVRTech", repository "pystrix", workflow "publish.yml",
@@ -14,15 +16,10 @@ permissions:
   contents: read
 
 jobs:
-  publish:
-    name: Publish to PyPI
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment:
-      name: pypi
-      url: https://pypi.org/project/pystrix/
-    permissions:
-      id-token: write  # required for Trusted Publishing (OIDC)
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -31,7 +28,41 @@ jobs:
           python-version: "3.11"
       - name: Build sdist and wheel
         run: |
-          python -m pip install build
+          python -m pip install build twine
           python -m build
+      - name: Verify artifacts and version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          test -n "$(ls -A dist/)" || { echo "::error::dist/ is empty"; exit 1; }
+          python -m twine check dist/*
+          version="$(python -c 'import pystrix; print(pystrix.VERSION)')"
+          if [ "$RELEASE_TAG" != "v$version" ] && [ "$RELEASE_TAG" != "$version" ]; then
+            echo "::error::built version $version does not match release tag $RELEASE_TAG"
+            exit 1
+          fi
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pystrix/
+    permissions:
+      contents: read
+      id-token: write  # required for Trusted Publishing (OIDC)
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+# Publishes to PyPI when a GitHub release is published. Authentication uses
+# PyPI Trusted Publishing (OIDC), so no API token is stored in the repo or CI.
+#
+# One-time PyPI setup (maintainer): add a Trusted Publisher to the pystrix
+# project with owner "IVRTech", repository "pystrix", workflow "publish.yml",
+# and environment "pypi".
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pystrix/
+    permissions:
+      id-token: write  # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes #58

## Summary

Auto-publishes pystrix to PyPI when a GitHub release is published, using **PyPI Trusted Publishing (OIDC)** — no API token is stored in the repo or CI.

## Workflow (`.github/workflows/publish.yml`)
- Triggers on `release: published`.
- Builds the sdist + wheel with `python -m build`, then uploads via `pypa/gh-action-pypi-publish` using OIDC.
- `contents: read` at the top level; the publish job requests `id-token: write` (needed for OIDC) and runs in a `pypi` GitHub Environment.

## Security
No untrusted input is used in any `run:` step; the only privilege is `id-token: write` scoped to the publish job. The trigger is `release: published`, which only a maintainer can fire.

## Required one-time setup (maintainer, on PyPI)
Add a Trusted Publisher to the existing `pystrix` PyPI project:
- Owner: `IVRTech`
- Repository: `pystrix`
- Workflow: `publish.yml`
- Environment: `pypi`

This requires owner/maintainer access to the existing `pystrix` PyPI project. Until it's configured, the publish job will fail at the upload step with an auth error (re-runnable once set up).

Optionally, add a required reviewer to the `pypi` GitHub Environment (repo settings) to gate each publish behind a manual approval.

## Sequence to ship 1.3.0
1. Merge this PR.
2. Merge the release PR (#57).
3. Configure the PyPI Trusted Publisher (above).
4. Tag `v1.3.0` and publish the GitHub release — the workflow then builds and uploads automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
