### PR TITLE
chore(ci): refresh actions and docs metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install ruff
@@ -35,9 +35,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install package with test dependencies
@@ -50,9 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -67,9 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Build sdist and wheel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Build sdist and wheel
@@ -42,7 +42,7 @@ jobs:
             exit 1
           fi
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7  # keep paired with download-artifact@v8 in the publish job
         with:
           name: dist
           path: dist/
@@ -60,7 +60,7 @@ jobs:
       id-token: write  # required for Trusted Publishing (OIDC)
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8  # keep paired with upload-artifact@v7 in the build job
         with:
           name: dist
           path: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- Refreshed documentation copyright metadata and moved GitHub Actions workflow dependencies to current Node 24-backed major versions (#60).
+
 ### Fixed
 - `Manager.monitor_connection` no longer crashes its monitoring thread when the connection drops. Pinging a downed connection raised `ManagerSocketError` (broken socket) or `ManagerError` (the liveness check inside `send_action` failing when the connection dropped just after the loop's own check) inside the thread, which dumped a traceback to stderr and killed the monitor. The monitor now catches both and stops cleanly, logging the reason at debug level when a logger is set. The method also returns the monitoring thread so callers can join it (#3).
 - `Manager.send_action` no longer raises a raw `AttributeError` when a concurrent `disconnect()` clears the connection between the liveness check and the send. It now drops the just-registered request and raises `ManagerSocketError` instead (#3).

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,7 @@ master_doc = "index"
 
 project = "pystrix"
 copyright = module.COPYRIGHT
+copyright_holder = module.COPYRIGHT.split(", ", 1)[1]
 version = re.match(r"^(\d+\.\d+)", module.VERSION).group(1)
 release = module.VERSION
 
@@ -41,7 +42,7 @@ latex_documents = [
         "index",
         "pystrix.tex",
         "pystrix Documentation",
-        re.search(", (.*?) <", module.COPYRIGHT).group(1),
+        copyright_holder,
         "manual",
     ),
 ]

--- a/pystrix/__init__.py
+++ b/pystrix/__init__.py
@@ -44,4 +44,4 @@ import pystrix.agi
 import pystrix.ami
 
 VERSION = "1.3.0"
-COPYRIGHT = "2013, Neil Tallim <flan@uguu.ca>"
+COPYRIGHT = "2026, IVR Technology Group"


### PR DESCRIPTION
## Summary
- Refresh docs-facing copyright metadata to `2026, IVR Technology Group` without publishing an email address.
- Move GitHub Actions workflow dependencies to the next major versions that replace the deprecated Node 20 runtime.
- Add Dependabot monitoring for GitHub Actions.

## Validation
- `python -m pytest -q`
- `ruff check .`
- `ruff format --check .`
- `python -m sphinx -W --keep-going -b html doc doc/_build/html`
- `python -m build`
- `python -m twine check dist/*`

## Notes
- The optional Read the Docs `v1.3.0` activation from #60 is a dashboard setting, not a repository change.

Addresses #60.