### PR TITLE
docs(agi): document FastAGI hangup signaling

### DIFF
--- a/doc/examples/fastagi.rst
+++ b/doc/examples/fastagi.rst
@@ -70,3 +70,31 @@ up::
             time.sleep(1)
         fastagi_core.kill()
         
+
+Hangup signaling
+----------------
+
+Asterisk sends FastAGI hangup notifications over the same network connection used for command
+responses. If ``HANGUP`` arrives while pystrix is waiting for a command response, pystrix consumes
+that notification and continues reading the actual response from Asterisk.
+
+If a channel hangs up while a long-running application such as ``Dial`` is active, Asterisk may also
+send a final ``HANGUP`` after the FastAGI handler has already returned and the socket has been
+closed. On some Asterisk versions this can appear in the Asterisk console as an
+``ast_carefulwrite`` ``Broken pipe`` error even though the FastAGI handler completed normally.
+
+Set ``AGISIGHUP`` before entering FastAGI if Asterisk should not send those hangup notifications::
+
+    exten => 97153654,1,Progress()
+    same => n,Set(AGISIGHUP=no)
+    same => n,AGI(agi://127.0.0.1/router)
+
+If Asterisk should instead stop AGI processing as soon as it detects the hangup, set
+``AGIEXITONHANGUP`` before entering FastAGI; Asterisk closes the AGI connection itself in this
+case::
+
+    exten => 97153654,1,Progress()
+    same => n,Set(AGIEXITONHANGUP=yes)
+    same => n,AGI(agi://127.0.0.1/router)
+
+A closed FastAGI connection is reported to pystrix as :class:`agi.AGISIGPIPEHangup`.


### PR DESCRIPTION
## Summary

- Document how Asterisk sends FastAGI `HANGUP` notifications over the AGI command socket.
- Explain why Asterisk can log `ast_carefulwrite` / `Broken pipe` after a handler returns during hangup-sensitive applications such as `Dial`.
- Add dialplan examples for `AGISIGHUP=no` and `AGIEXITONHANGUP=yes`.

## Root Cause

Asterisk 11's AGI runner sends a final FastAGI `HANGUP` notification when the channel hangs up and `AGISIGHUP` is enabled. If the FastAGI handler has already returned, the server-side socket is closed and Asterisk's final write can surface as `ast_carefulwrite: write() returned error: Broken pipe`. This is controlled by Asterisk dialplan variables before entering FastAGI rather than by pystrix runtime code.

Closes #5.

## Validation

- `python -m pytest -q` -> 72 passed
- `ruff check .` -> All checks passed
- `ruff format --check .` -> 26 files already formatted
- `python -m sphinx -b html doc /private/tmp/pystrix-doc-build-issue-5` -> build succeeded